### PR TITLE
feat: Pass scale to onUpdateOverlayBounds callback

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/ApplicationScreen.kt
@@ -145,6 +145,7 @@ internal fun ApplicationScreen(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onVerticalDrag: (Float) -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
@@ -20,6 +20,8 @@ package com.eblan.launcher.feature.home.screen.application
 import android.graphics.Rect
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
@@ -44,6 +46,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
@@ -115,6 +118,7 @@ internal fun EblanApplicationInfoGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
@@ -181,6 +185,8 @@ internal fun EblanApplicationInfoGridItem(
         parent = SharedElementKey.Parent.SwipeY,
     )
 
+    val scale = remember { Animatable(1f) }
+
     LaunchedEffect(
         key1 = drag,
         key2 = isLongPress,
@@ -234,6 +240,7 @@ internal fun EblanApplicationInfoGridItem(
                                     intSize = intSize,
                                     keyboardController = keyboardController,
                                     sharedElementKey = sharedElementKey,
+                                    scale = scale,
                                     onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateIsLongPress = { isLongPress = it },
@@ -246,6 +253,15 @@ internal fun EblanApplicationInfoGridItem(
                         }
                     } else {
                         null
+                    },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
                     },
                 )
             }
@@ -272,15 +288,9 @@ internal fun EblanApplicationInfoGridItem(
                 .crossfade(false)
                 .build(),
             contentDescription = null,
-            modifier = Modifier.size(appDrawerSettings.gridItemSettings.iconSize.dp)
-                .alpha(alpha)
-                .drawWithContent {
-                    graphicsLayer.record {
-                        this@drawWithContent.drawContent()
-                    }
-
-                    drawLayer(graphicsLayer)
-                }.onGloballyPositioned { layoutCoordinates ->
+            modifier = Modifier
+                .size(appDrawerSettings.gridItemSettings.iconSize.dp)
+                .onGloballyPositioned { layoutCoordinates ->
                     intOffset = layoutCoordinates.positionInRoot().round()
 
                     intSize = layoutCoordinates.size
@@ -302,6 +312,17 @@ internal fun EblanApplicationInfoGridItem(
                     } else {
                         this
                     }
+                }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                }
+                .drawWithContent {
+                    graphicsLayer.record {
+                        this@drawWithContent.drawContent()
+                    }
+
+                    drawLayer(graphicsLayer)
                 },
         )
 
@@ -441,11 +462,16 @@ internal suspend fun handleOnLongPressEblanApplicationInfoItem(
     intSize: IntSize,
     keyboardController: SoftwareKeyboardController?,
     sharedElementKey: SharedElementKey,
+    scale: Animatable<Float, AnimationVector1D>,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateIsLongPress: (Boolean) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+        scale: Float,
+    ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {
@@ -454,6 +480,7 @@ internal suspend fun handleOnLongPressEblanApplicationInfoItem(
     onUpdateOverlayBounds(
         intOffset,
         intSize,
+        scale.value,
     )
 
     onUpdateSharedElementKey(sharedElementKey)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/Popup.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/Popup.kt
@@ -92,6 +92,7 @@ internal fun ApplicationInfoPopup(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onWidgets: (EblanApplicationInfoGroup) -> Unit,
@@ -417,6 +418,7 @@ private fun ApplicationInfoMenu(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onWidgets: () -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
@@ -22,6 +22,8 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -103,6 +105,7 @@ internal fun LazyGridScope.privateSpace(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
@@ -243,6 +246,7 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
@@ -297,6 +301,8 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
         appDrawerSettings.gridItemSettings.iconSize.dp.roundToPx()
     }
 
+    val scale = remember { Animatable(1f) }
+
     Column(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay) {
@@ -322,18 +328,28 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
                         {
                             scope.launch {
                                 handleOnLongPressPrivateSpaceEblanApplicationInfoItem(
-                                    onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                                     eblanApplicationInfo = eblanApplicationInfo,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
                                     intOffset = intOffset,
                                     intSize = intSize,
-                                    onUpdatePopupMenu = onUpdatePopupMenu,
                                     keyboardController = keyboardController,
+                                    scale = scale,
+                                    onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
+                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
+                                    onUpdatePopupMenu = onUpdatePopupMenu,
                                 )
                             }
                         }
                     } else {
                         null
+                    },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
                     },
                 )
             }
@@ -380,19 +396,25 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
 }
 
 internal fun handleOnLongPressPrivateSpaceEblanApplicationInfoItem(
-    onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
     eblanApplicationInfo: EblanApplicationInfo,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
     intOffset: IntOffset,
     intSize: IntSize,
-    onUpdatePopupMenu: (Boolean) -> Unit,
     keyboardController: SoftwareKeyboardController?,
+    scale: Animatable<Float, AnimationVector1D>,
+    onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+        scale: Float,
+    ) -> Unit,
+    onUpdatePopupMenu: (Boolean) -> Unit,
 ) {
     onUpdateEblanApplicationInfo(eblanApplicationInfo)
 
     onUpdateOverlayBounds(
         intOffset,
         intSize,
+        scale.value,
     )
 
     onUpdatePopupMenu(true)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/horizontal/HorizontalApplicationScreen.kt
@@ -118,6 +118,7 @@ internal fun HorizontalApplicationScreen(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onVerticalDrag: (Float) -> Unit,
@@ -237,8 +238,12 @@ internal fun HorizontalApplicationScreen(
                 onUpdateGridItemSource = onUpdateGridItemSource,
                 onUpdateImageBitmap = onUpdateImageBitmap,
                 onUpdateIsDragging = onUpdateIsDragging,
-                onUpdateOverlayBounds = { intOffset, intSize ->
-                    onUpdateOverlayBounds(intOffset, intSize)
+                onUpdateOverlayBounds = { intOffset, intSize, scale ->
+                    onUpdateOverlayBounds(
+                        intOffset,
+                        intSize,
+                        scale,
+                    )
 
                     popupIntOffset = intOffset
 
@@ -334,6 +339,7 @@ private fun EblanApplicationInfosPage(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdatePrivatePopupMenu: (Boolean) -> Unit,
@@ -465,6 +471,7 @@ private fun EblanApplicationInfos(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdatePrivatePopupMenu: (Boolean) -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -20,6 +20,7 @@ package com.eblan.launcher.feature.home.screen.application.list
 import android.os.Build
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -159,6 +160,7 @@ internal fun ListApplicationScreen(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onVerticalDrag: (Float) -> Unit,
@@ -284,8 +286,12 @@ internal fun ListApplicationScreen(
                 onUpdateGridItemSource = onUpdateGridItemSource,
                 onUpdateImageBitmap = onUpdateImageBitmap,
                 onUpdateIsDragging = onUpdateIsDragging,
-                onUpdateOverlayBounds = { intOffset, intSize ->
-                    onUpdateOverlayBounds(intOffset, intSize)
+                onUpdateOverlayBounds = { intOffset, intSize, scale ->
+                    onUpdateOverlayBounds(
+                        intOffset,
+                        intSize,
+                        scale,
+                    )
 
                     popupIntOffset = intOffset
 
@@ -382,6 +388,7 @@ private fun EblanApplicationInfosPage(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdatePrivatePopupMenu: (Boolean) -> Unit,
@@ -515,6 +522,7 @@ private fun EblanApplicationInfos(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdatePrivatePopupMenu: (Boolean) -> Unit,
@@ -708,6 +716,7 @@ private fun EblanApplicationInfoListItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
@@ -768,6 +777,8 @@ private fun EblanApplicationInfoListItem(
         parent = SharedElementKey.Parent.SwipeY,
     )
 
+    val scale = remember { Animatable(1f) }
+
     LaunchedEffect(
         key1 = drag,
         key2 = isLongPress,
@@ -821,6 +832,7 @@ private fun EblanApplicationInfoListItem(
                                     intOffset = intOffset,
                                     intSize = intSize,
                                     keyboardController = keyboardController,
+                                    scale = scale,
                                     onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateIsLongPress = { isLongPress = it },

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
@@ -18,6 +18,7 @@
 package com.eblan.launcher.feature.home.screen.application.list
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -41,6 +42,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -88,6 +90,7 @@ internal fun LazyListScope.privateSpace(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
@@ -141,6 +144,7 @@ private fun PrivateSpaceEblanApplicationInfoItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
@@ -187,6 +191,8 @@ private fun PrivateSpaceEblanApplicationInfoItem(
         appDrawerSettings.gridItemSettings.iconSize.dp.roundToPx()
     }
 
+    val scale = remember { Animatable(1f) }
+
     Row(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay) {
@@ -212,18 +218,28 @@ private fun PrivateSpaceEblanApplicationInfoItem(
                         {
                             scope.launch {
                                 handleOnLongPressPrivateSpaceEblanApplicationInfoItem(
-                                    onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
                                     eblanApplicationInfo = eblanApplicationInfo,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
                                     intOffset = intOffset,
                                     intSize = intSize,
-                                    onUpdatePopupMenu = onUpdatePopupMenu,
                                     keyboardController = keyboardController,
+                                    scale = scale,
+                                    onUpdateEblanApplicationInfo = onUpdateEblanApplicationInfo,
+                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
+                                    onUpdatePopupMenu = onUpdatePopupMenu,
                                 )
                             }
                         }
                     } else {
                         null
+                    },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
                     },
                 )
             }
@@ -246,7 +262,11 @@ private fun PrivateSpaceEblanApplicationInfoItem(
 
                     intSize = layoutCoordinates.size
                 }
-                .size(appDrawerSettings.gridItemSettings.iconSize.dp),
+                .size(appDrawerSettings.gridItemSettings.iconSize.dp)
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                },
             placeholder = ColorPainter(Color.Transparent),
             error = ColorPainter(Color.Transparent),
         )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/vertical/VerticalApplicationScreen.kt
@@ -133,6 +133,7 @@ internal fun VerticalApplicationScreen(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onVerticalDrag: (Float) -> Unit,
@@ -274,8 +275,12 @@ internal fun VerticalApplicationScreen(
                 onUpdateGridItemSource = onUpdateGridItemSource,
                 onUpdateImageBitmap = onUpdateImageBitmap,
                 onUpdateIsDragging = onUpdateIsDragging,
-                onUpdateOverlayBounds = { intOffset, intSize ->
-                    onUpdateOverlayBounds(intOffset, intSize)
+                onUpdateOverlayBounds = { intOffset, intSize, scale ->
+                    onUpdateOverlayBounds(
+                        intOffset,
+                        intSize,
+                        scale,
+                    )
 
                     popupIntOffset = intOffset
 
@@ -376,6 +381,7 @@ private fun EblanApplicationInfosPage(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdatePrivatePopupMenu: (Boolean) -> Unit,
@@ -524,6 +530,7 @@ private fun EblanApplicationInfos(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdatePrivatePopupMenu: (Boolean) -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderDragGridItemHelper.kt
@@ -17,6 +17,8 @@
  */
 package com.eblan.launcher.feature.home.screen.folder
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.State
 import androidx.compose.ui.graphics.ImageBitmap
@@ -59,10 +61,12 @@ internal suspend fun onLongPressFolderGridItem(
     intSize: IntSize,
     sharedElementKey: SharedElementKey,
     gridItem: GridItem,
+    scale: Animatable<Float, AnimationVector1D>,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onShowGridItemPopup: (
@@ -85,6 +89,7 @@ internal suspend fun onLongPressFolderGridItem(
     onUpdateOverlayBounds(
         intOffset,
         intSize,
+        scale.value,
     )
 
     onUpdateSharedElementKey(sharedElementKey)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderGridItemPopup.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderGridItemPopup.kt
@@ -93,6 +93,7 @@ internal fun FolderGridItemPopup(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onWidgets: (EblanApplicationInfoGroup) -> Unit,
@@ -261,6 +262,7 @@ private fun FolderGridItemPopupContent(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onWidgets: (EblanApplicationInfoGroup) -> Unit,
@@ -394,6 +396,7 @@ private fun ApplicationInfoFolderGridItemPopupContent(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onWidgets: () -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -118,6 +118,7 @@ internal fun FolderScreen(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onShowGridItemPopup: (

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -22,6 +22,7 @@ import android.graphics.Rect
 import android.os.Build
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -49,6 +50,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -120,6 +122,7 @@ internal fun InteractiveFolderGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onShowGridItemPopup: (
@@ -318,6 +321,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
@@ -358,6 +362,8 @@ private fun InteractiveFolderApplicationInfoGridItem(
 
     val isNotificationAccessGranted by rememberIsNotificationAccessGranted()
 
+    val scale = remember { Animatable(1f) }
+
     Column(
         modifier = modifier
             .pointerInput(
@@ -386,6 +392,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
+                                    scale = scale,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateOverlayBounds = onUpdateOverlayBounds,
                                     onUpdateSharedElementKey = onUpdateSharedElementKey,
@@ -408,6 +415,15 @@ private fun InteractiveFolderApplicationInfoGridItem(
                         }
                     } else {
                         null
+                    },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
                     },
                 )
             }
@@ -455,6 +471,10 @@ private fun InteractiveFolderApplicationInfoGridItem(
                         } else {
                             this
                         }
+                    }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.record {
@@ -518,6 +538,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
@@ -554,6 +575,8 @@ private fun InteractiveFolderShortcutInfoGridItem(
 
     val alpha = if (hasInteraction) 0f else defaultAlpha
 
+    val scale = remember { Animatable(1f) }
+
     Column(
         modifier = modifier
             .pointerInput(
@@ -584,6 +607,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
+                                    scale = scale,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateOverlayBounds = onUpdateOverlayBounds,
                                     onUpdateSharedElementKey = onUpdateSharedElementKey,
@@ -657,6 +681,10 @@ private fun InteractiveFolderShortcutInfoGridItem(
                             this
                         }
                     }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
+                    }
                     .drawWithContent {
                         graphicsLayer.apply {
                             this.alpha = alpha
@@ -720,6 +748,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
@@ -762,6 +791,8 @@ private fun InteractiveFolderShortcutConfigGridItem(
 
     val alpha = if (hasInteraction) 0f else 1f
 
+    val scale = remember { Animatable(1f) }
+
     Column(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay && !isInProgress) {
@@ -787,6 +818,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
+                                    scale = scale,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateOverlayBounds = onUpdateOverlayBounds,
                                     onUpdateSharedElementKey = onUpdateSharedElementKey,
@@ -906,6 +938,7 @@ private fun InteractiveNestedFolderGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
@@ -933,6 +966,8 @@ private fun InteractiveNestedFolderGridItem(
     val hasInteraction = isSelected && isVisibleOverlay
 
     val alpha = if (hasInteraction) 0f else 1f
+
+    val scale = remember { Animatable(1f) }
 
     LaunchedEffect(
         key1 = drag,
@@ -974,6 +1009,7 @@ private fun InteractiveNestedFolderGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
+                                    scale = scale,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateOverlayBounds = onUpdateOverlayBounds,
                                     onUpdateSharedElementKey = onUpdateSharedElementKey,
@@ -1040,6 +1076,10 @@ private fun InteractiveNestedFolderGridItem(
                     } else {
                         this
                     }
+                }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
                 }
                 .drawWithContent {
                     graphicsLayer.record {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/DragGridItemHelper.kt
@@ -17,6 +17,8 @@
  */
 package com.eblan.launcher.feature.home.screen.pager
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.State
 import androidx.compose.ui.graphics.ImageBitmap
@@ -73,11 +75,13 @@ internal suspend fun onLongPress(
     intSize: IntSize,
     sharedElementKey: SharedElementKey,
     gridItem: GridItem,
+    scale: Animatable<Float, AnimationVector1D>,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onShowGridItemPopup: (
@@ -102,6 +106,8 @@ internal suspend fun onLongPress(
     onUpdateOverlayBounds(
         intOffset,
         intSize,
+        scale.value,
+
     )
 
     onUpdateSharedElementKey(sharedElementKey)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/GridItemPopup.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/GridItemPopup.kt
@@ -89,7 +89,11 @@ internal fun GridItemPopup(
     onResize: (GridItem) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
-    onUpdateOverlayBounds: (intOffset: IntOffset, intSize: IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+        scale: Float,
+    ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onWidgets: (EblanApplicationInfoGroup) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
@@ -255,6 +259,7 @@ private fun GridItemPopupContent(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onWidgets: (EblanApplicationInfoGroup) -> Unit,
@@ -412,6 +417,7 @@ private fun ApplicationInfoGridItemMenu(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onWidgets: () -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -22,6 +22,7 @@ import android.graphics.Rect
 import android.os.Build
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -49,6 +50,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -125,6 +127,7 @@ internal fun InteractiveGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onShowGridItemPopup: (
@@ -361,6 +364,7 @@ private fun InteractiveApplicationInfoGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
@@ -399,6 +403,8 @@ private fun InteractiveApplicationInfoGridItem(
 
     val isNotificationAccessGranted by rememberIsNotificationAccessGranted()
 
+    val scale = remember { Animatable(1f) }
+
     Column(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay) {
@@ -424,6 +430,7 @@ private fun InteractiveApplicationInfoGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
+                                    scale = scale,
                                     onUpdateGridItemSource = onUpdateGridItemSource,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateOverlayBounds = onUpdateOverlayBounds,
@@ -447,6 +454,15 @@ private fun InteractiveApplicationInfoGridItem(
                         }
                     } else {
                         null
+                    },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
                     },
                 )
             }
@@ -499,6 +515,10 @@ private fun InteractiveApplicationInfoGridItem(
                         } else {
                             this
                         }
+                    }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.record {
@@ -559,6 +579,7 @@ private fun InteractiveWidgetGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
@@ -578,6 +599,14 @@ private fun InteractiveWidgetGridItem(
     var intOffset by remember { mutableStateOf(IntOffset.Zero) }
 
     var intSize by remember { mutableStateOf(IntSize.Zero) }
+
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.animateTo(targetValue = 1f)
+        }
+    }
 
     Box(
         modifier = modifier
@@ -605,6 +634,10 @@ private fun InteractiveWidgetGridItem(
                     this
                 }
             }
+            .graphicsLayer {
+                scaleX = scale.value
+                scaleY = scale.value
+            }
             .drawWithContent {
                 graphicsLayer.record {
                     this@drawWithContent.drawContent()
@@ -627,12 +660,15 @@ private fun InteractiveWidgetGridItem(
                     if (!isVisibleOverlay) {
                         it.setOnLongClickListener {
                             scope.launch {
+                                scale.animateTo(0.85f)
+
                                 onLongPress(
                                     graphicsLayer = graphicsLayer,
                                     intOffset = intOffset,
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
+                                    scale = scale,
                                     onUpdateGridItemSource = onUpdateGridItemSource,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateOverlayBounds = onUpdateOverlayBounds,
@@ -663,6 +699,7 @@ private fun InteractiveWidgetGridItem(
                                         intSize = intSize,
                                         sharedElementKey = sharedElementKey,
                                         gridItem = gridItem,
+                                        scale = scale,
                                         onUpdateGridItemSource = onUpdateGridItemSource,
                                         onUpdateImageBitmap = onUpdateImageBitmap,
                                         onUpdateOverlayBounds = onUpdateOverlayBounds,
@@ -675,6 +712,16 @@ private fun InteractiveWidgetGridItem(
                             }
                         } else {
                             null
+                        },
+
+                        onPress = {
+                            scale.animateTo(targetValue = 0.85f)
+
+                            try {
+                                awaitRelease()
+                            } finally {
+                                scale.animateTo(targetValue = 1f)
+                            }
                         },
                     )
                 },
@@ -711,6 +758,7 @@ private fun InteractiveShortcutInfoGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
@@ -745,6 +793,8 @@ private fun InteractiveShortcutInfoGridItem(
 
     val alpha = if (hasInteraction) 0f else defaultAlpha
 
+    val scale = remember { Animatable(1f) }
+
     Column(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay) {
@@ -770,6 +820,7 @@ private fun InteractiveShortcutInfoGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
+                                    scale = scale,
                                     onUpdateGridItemSource = onUpdateGridItemSource,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateOverlayBounds = onUpdateOverlayBounds,
@@ -799,6 +850,15 @@ private fun InteractiveShortcutInfoGridItem(
                         }
                     } else {
                         null
+                    },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
                     },
                 )
             }
@@ -849,6 +909,10 @@ private fun InteractiveShortcutInfoGridItem(
                         } else {
                             this
                         }
+                    }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.apply {
@@ -924,6 +988,7 @@ private fun InteractiveFolderGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
@@ -963,6 +1028,8 @@ private fun InteractiveFolderGridItem(
     val currentLockMovement = rememberUpdatedState(lockMovement)
     val currentFolderGridItems =
         rememberUpdatedState(previewFolderGridItems[gridItem.id]?.folderGridItems)
+
+    val scale = remember { Animatable(1f) }
 
     LaunchedEffect(key1 = moveGridItemResult) {
         handleConflictingGridItem(
@@ -1006,6 +1073,7 @@ private fun InteractiveFolderGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
+                                    scale = scale,
                                     onUpdateGridItemSource = onUpdateGridItemSource,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateOverlayBounds = onUpdateOverlayBounds,
@@ -1036,6 +1104,15 @@ private fun InteractiveFolderGridItem(
                         }
                     } else {
                         null
+                    },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
                     },
                 )
             }
@@ -1077,6 +1154,10 @@ private fun InteractiveFolderGridItem(
                 } else {
                     this
                 }
+            }
+            .graphicsLayer {
+                scaleX = scale.value
+                scaleY = scale.value
             }
             .drawWithContent {
                 graphicsLayer.record {
@@ -1164,6 +1245,7 @@ private fun InteractiveShortcutConfigGridItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
@@ -1204,6 +1286,8 @@ private fun InteractiveShortcutConfigGridItem(
 
     val alpha = if (hasInteraction) 0f else 1f
 
+    val scale = remember { Animatable(1f) }
+
     Column(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay) {
@@ -1229,6 +1313,7 @@ private fun InteractiveShortcutConfigGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
+                                    scale = scale,
                                     onUpdateGridItemSource = onUpdateGridItemSource,
                                     onUpdateImageBitmap = onUpdateImageBitmap,
                                     onUpdateOverlayBounds = onUpdateOverlayBounds,
@@ -1250,6 +1335,15 @@ private fun InteractiveShortcutConfigGridItem(
                         }
                     } else {
                         null
+                    },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
                     },
                 )
             }
@@ -1298,6 +1392,10 @@ private fun InteractiveShortcutConfigGridItem(
                     } else {
                         this
                     }
+                }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
                 }
                 .drawWithContent {
                     graphicsLayer.record {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -37,6 +37,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.draganddrop.dragAndDropTarget
@@ -73,6 +74,7 @@ import androidx.compose.ui.draganddrop.mimeTypes
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -1191,6 +1193,7 @@ internal fun PagerScreen(
             sharedElementKey = pagerScreenState.sharedElementKey,
             isVisibleOverlay = isVisibleOverlay,
             screenWidth = screenWidth,
+            scale = pagerScreenState.overlayScale,
             onResetOverlay = pagerScreenState::resetOverlay,
         )
     }
@@ -1206,6 +1209,7 @@ private fun SharedTransitionScope.OverlayImage(
     sharedElementKey: SharedElementKey?,
     isVisibleOverlay: Boolean,
     screenWidth: Int,
+    scale: Float,
     onResetOverlay: () -> Unit,
 ) {
     if (overlayImageBitmap == null ||
@@ -1224,8 +1228,12 @@ private fun SharedTransitionScope.OverlayImage(
         DpSize(width = overlayIntSize.width.toDp(), height = overlayIntSize.height.toDp())
     }
 
+    val scale = remember { Animatable(scale) }
+
     LaunchedEffect(key1 = isVisibleOverlay) {
-        if (!isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.animateTo(targetValue = 1f)
+        } else {
             onResetOverlay()
         }
     }
@@ -1243,6 +1251,10 @@ private fun SharedTransitionScope.OverlayImage(
                 }
             }
             .size(size)
+            .graphicsLayer {
+                scaleX = scale.value
+                scaleY = scale.value
+            }
             .sharedElementWithCallerManagedVisibility(
                 rememberSharedContentState(key = sharedElementKey),
                 visible = isVisibleOverlay,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreenState.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -307,6 +308,9 @@ internal class PagerScreenState(
             !showFolderGridItemPopup &&
             eblanApplicationInfoGroup == null
 
+    var overlayScale by mutableFloatStateOf(1f)
+        private set
+
     private val touchSlop = with(density) {
         50.dp.toPx()
     }
@@ -385,10 +389,13 @@ internal class PagerScreenState(
     fun updateOverlayBounds(
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) {
         overlayIntOffset = intOffset
 
         overlayIntSize = intSize
+
+        overlayScale = scale
     }
 
     fun resetOverlay() {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
@@ -122,6 +122,7 @@ internal fun ShortcutConfigScreen(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
@@ -291,7 +292,11 @@ private fun EblanShortcutConfigsPage(
     paddingValues: PaddingValues,
     swipeY: Float,
     onDragEnd: () -> Unit,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+        scale: Float,
+    ) -> Unit,
     onVerticalDrag: (Float) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
@@ -369,6 +374,7 @@ private fun EblanApplicationInfoItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
@@ -451,6 +457,7 @@ private fun EblanShortcutConfigItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
@@ -538,7 +545,11 @@ private suspend fun handleOnLongPress(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     graphicsLayer: GraphicsLayer,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+        scale: Float,
+    ) -> Unit,
     intOffset: IntOffset,
     intSize: IntSize,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
@@ -570,6 +581,7 @@ private suspend fun handleOnLongPress(
     onUpdateOverlayBounds(
         intOffset,
         intSize,
+        1f,
     )
 
     onUpdateSharedElementKey(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutinfo/ShortcutInfoScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutinfo/ShortcutInfoScreen.kt
@@ -81,6 +81,7 @@ internal fun ShortcutInfoScreen(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
@@ -159,6 +160,7 @@ private fun ShortcutInfoMenuItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
@@ -168,8 +170,6 @@ private fun ShortcutInfoMenuItem(
     val graphicsLayer = rememberGraphicsLayer()
 
     val scope = rememberCoroutineScope()
-
-    var isLongPress by remember { mutableStateOf(false) }
 
     var intOffset by remember { mutableStateOf(IntOffset.Zero) }
 
@@ -228,13 +228,11 @@ private fun ShortcutInfoMenuItem(
                     }
                     .size(30.dp),
             ) {
-                if (!isLongPress) {
-                    AsyncImage(
-                        model = eblanShortcutInfo.icon,
-                        contentDescription = null,
-                        modifier = Modifier.matchParentSize(),
-                    )
-                }
+                AsyncImage(
+                    model = eblanShortcutInfo.icon,
+                    contentDescription = null,
+                    modifier = Modifier.matchParentSize(),
+                )
             }
         },
     )
@@ -249,7 +247,11 @@ private suspend fun handleOnLongPress(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     graphicsLayer: GraphicsLayer,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+        scale: Float,
+    ) -> Unit,
     intOffset: IntOffset,
     intSize: IntSize,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
@@ -281,6 +283,7 @@ private suspend fun handleOnLongPress(
     onUpdateOverlayBounds(
         intOffset,
         intSize,
+        1f,
     )
 
     onUpdateSharedElementKey(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/AppWidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/AppWidgetScreen.kt
@@ -94,6 +94,7 @@ internal fun AppWidgetScreen(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
@@ -210,6 +211,7 @@ private fun EblanAppWidgetProviderInfoItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
@@ -339,7 +341,11 @@ private suspend fun handleOnLongPress(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     graphicsLayer: GraphicsLayer,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+        scale: Float,
+    ) -> Unit,
     intOffset: IntOffset,
     intSize: IntSize,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
@@ -385,6 +391,7 @@ private suspend fun handleOnLongPress(
     onUpdateOverlayBounds(
         intOffset,
         intSize,
+        1f,
     )
 
     onUpdateSharedElementKey(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
@@ -115,6 +115,7 @@ internal fun WidgetScreen(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
@@ -247,6 +248,7 @@ private fun EblanApplicationInfoItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
@@ -337,6 +339,7 @@ private fun EblanAppWidgetProviderInfoItem(
     onUpdateOverlayBounds: (
         intOffset: IntOffset,
         intSize: IntSize,
+        scale: Float,
     ) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
@@ -471,7 +474,11 @@ private suspend fun handleOnLongPress(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     graphicsLayer: GraphicsLayer,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+        scale: Float,
+    ) -> Unit,
     intOffset: IntOffset,
     intSize: IntSize,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
@@ -519,6 +526,7 @@ private suspend fun handleOnLongPress(
     onUpdateOverlayBounds(
         intOffset,
         intSize,
+        1f,
     )
 
     onUpdateSharedElementKey(


### PR DESCRIPTION
This commit introduces a new `scale` parameter to the `onUpdateOverlayBounds` callback. This change allows for more accurate positioning and sizing of overlay elements by providing the current scaling factor.

Closes #980 

The `scale` parameter is now passed down through various Composable functions that utilize the `onUpdateOverlayBounds` callback, including:

- `EblanApplicationInfoGridItem`
- `InteractiveFolderGridItem`
- `InteractiveGridItem`
- `FolderGridItemPopup`
- `Popup`
- `FolderScreen`
- `VerticalApplicationScreen`
- `HorizontalApplicationScreen`
- `PrivateSpaceScreen`
- `ListApplicationScreen`
- `PagerScreenState`
- `PagerScreen`
- `GridItemPopup`
- `AppWidgetScreen`
- `WidgetScreen`
- `ShortcutConfigScreen`
- `ShortcutInfoScreen`

Additionally, a new `Animatable` scale state is introduced in several components to handle visual scaling effects during press events, further enhancing the user experience. This includes adding press animations to various grid items and popups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added press feedback for app, folder, shortcut, widget, and private-space items, smoothly shrinking icons while pressed and restoring them on release.
  * Improved overlay transitions so animated item scaling is preserved during long-press actions and popup displays.
  * Shortcut icons now remain visible while interacting with their menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->