### PR TITLE
Added Item Scale Animation

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-08-30T00:49:09.861272277Z">
+        <DropdownSelection timestamp="2026-08-30T01:18:13.344335727Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack/.android/avd/Pixel_XL.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack/.android/avd/Pixel_9a.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-08-24T22:14:00.856250957Z">
+        <DropdownSelection timestamp="2026-08-30T00:49:09.861272277Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack/.android/avd/Pixel_9a.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/home/jack/.android/avd/Pixel_XL.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
@@ -17,9 +17,12 @@
  */
 package com.eblan.launcher.feature.home.screen.application
 
+import android.R.attr.scaleX
+import android.R.attr.scaleY
 import android.graphics.Rect
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
@@ -44,6 +47,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
@@ -181,6 +185,14 @@ internal fun EblanApplicationInfoGridItem(
         parent = SharedElementKey.Parent.SwipeY,
     )
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     LaunchedEffect(
         key1 = drag,
         key2 = isLongPress,
@@ -247,6 +259,15 @@ internal fun EblanApplicationInfoGridItem(
                     } else {
                         null
                     },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
+                    },
                 )
             }
             .run {
@@ -272,15 +293,9 @@ internal fun EblanApplicationInfoGridItem(
                 .crossfade(false)
                 .build(),
             contentDescription = null,
-            modifier = Modifier.size(appDrawerSettings.gridItemSettings.iconSize.dp)
-                .alpha(alpha)
-                .drawWithContent {
-                    graphicsLayer.record {
-                        this@drawWithContent.drawContent()
-                    }
-
-                    drawLayer(graphicsLayer)
-                }.onGloballyPositioned { layoutCoordinates ->
+            modifier = Modifier
+                .size(appDrawerSettings.gridItemSettings.iconSize.dp)
+                .onGloballyPositioned { layoutCoordinates ->
                     intOffset = layoutCoordinates.positionInRoot().round()
 
                     intSize = layoutCoordinates.size
@@ -302,7 +317,19 @@ internal fun EblanApplicationInfoGridItem(
                     } else {
                         this
                     }
-                },
+                }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                }
+                .drawWithContent {
+                    graphicsLayer.record {
+                        this@drawWithContent.drawContent()
+                    }
+
+                    drawLayer(graphicsLayer)
+                }
+                .alpha(alpha),
         )
 
         if (appDrawerSettings.gridItemSettings.showLabel) {
@@ -445,7 +472,10 @@ internal suspend fun handleOnLongPressEblanApplicationInfoItem(
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateIsLongPress: (Boolean) -> Unit,
     onUpdateIsVisibleOverlay: (Boolean) -> Unit,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+    ) -> Unit,
     onUpdatePopupMenu: (Boolean) -> Unit,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,
 ) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
@@ -81,6 +81,7 @@ import com.eblan.launcher.domain.model.TextColor
 import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.model.SharedElementKey
+import com.eblan.launcher.feature.home.util.SCALE
 import com.eblan.launcher.feature.home.util.getAppDrawerGridItemTextColor
 import com.eblan.launcher.feature.home.util.getHorizontalAlignment
 import com.eblan.launcher.feature.home.util.getVerticalArrangement
@@ -272,7 +273,7 @@ internal fun EblanApplicationInfoGridItem(
                         null
                     },
                     onPress = {
-                        scale.animateTo(targetValue = 0.85f)
+                        scale.animateTo(targetValue = SCALE)
 
                         try {
                             awaitRelease()

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/EblanApplicationInfoGridItem.kt
@@ -17,8 +17,6 @@
  */
 package com.eblan.launcher.feature.home.screen.application
 
-import android.R.attr.scaleX
-import android.R.attr.scaleY
 import android.graphics.Rect
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
@@ -217,6 +215,20 @@ internal fun EblanApplicationInfoGridItem(
 
     Column(
         modifier = modifier
+            .run {
+                if (appDrawerType == AppDrawerType.Vertical) {
+                    height(appDrawerSettings.appDrawerRowsHeight.dp)
+                } else {
+                    fillMaxSize()
+                }
+            }
+            .padding(appDrawerSettings.gridItemSettings.padding.dp)
+            .background(
+                color = Color(appDrawerSettings.gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(
+                    size = appDrawerSettings.gridItemSettings.cornerRadius.dp,
+                ),
+            )
             .pointerInput(key1 = isVisibleOverlay) {
                 detectTapGestures(
                     onTap = if (!isVisibleOverlay) {
@@ -269,19 +281,7 @@ internal fun EblanApplicationInfoGridItem(
                         }
                     },
                 )
-            }
-            .run {
-                if (appDrawerType == AppDrawerType.Vertical) {
-                    height(appDrawerSettings.appDrawerRowsHeight.dp)
-                } else {
-                    fillMaxSize()
-                }
-            }
-            .padding(appDrawerSettings.gridItemSettings.padding.dp)
-            .background(
-                color = Color(appDrawerSettings.gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = appDrawerSettings.gridItemSettings.cornerRadius.dp),
-            ),
+            },
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
     ) {
@@ -300,6 +300,10 @@ internal fun EblanApplicationInfoGridItem(
 
                     intSize = layoutCoordinates.size
                 }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                }
                 .run {
                     if (!isSwiping &&
                         !isScrollInProgress &&
@@ -317,10 +321,6 @@ internal fun EblanApplicationInfoGridItem(
                     } else {
                         this
                     }
-                }
-                .graphicsLayer {
-                    scaleX = scale.value
-                    scaleY = scale.value
                 }
                 .drawWithContent {
                     graphicsLayer.record {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
@@ -22,6 +22,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -42,6 +43,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,6 +52,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -297,6 +300,14 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
         appDrawerSettings.gridItemSettings.iconSize.dp.roundToPx()
     }
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     Column(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay) {
@@ -335,6 +346,15 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
                     } else {
                         null
                     },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
+                    },
                 )
             }
             .height(appDrawerRowsHeight)
@@ -355,12 +375,16 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
                 .build(),
             contentDescription = null,
             modifier = Modifier
+                .size(appDrawerSettings.gridItemSettings.iconSize.dp)
                 .onGloballyPositioned { layoutCoordinates ->
                     intOffset = layoutCoordinates.positionInRoot().round()
 
                     intSize = layoutCoordinates.size
                 }
-                .size(appDrawerSettings.gridItemSettings.iconSize.dp),
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                },
             placeholder = ColorPainter(Color.Transparent),
             error = ColorPainter(Color.Transparent),
         )
@@ -382,7 +406,10 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
 internal fun handleOnLongPressPrivateSpaceEblanApplicationInfoItem(
     onUpdateEblanApplicationInfo: (EblanApplicationInfo) -> Unit,
     eblanApplicationInfo: EblanApplicationInfo,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+    ) -> Unit,
     intOffset: IntOffset,
     intSize: IntSize,
     onUpdatePopupMenu: (Boolean) -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
@@ -81,6 +81,7 @@ import com.eblan.launcher.domain.model.EblanApplicationInfo
 import com.eblan.launcher.domain.model.EblanUser
 import com.eblan.launcher.domain.model.TextColor
 import com.eblan.launcher.feature.home.R
+import com.eblan.launcher.feature.home.util.SCALE
 import com.eblan.launcher.feature.home.util.getAppDrawerGridItemTextColor
 import com.eblan.launcher.feature.home.util.getApplicationScreenTextColor
 import com.eblan.launcher.feature.home.util.getHorizontalAlignment
@@ -355,7 +356,7 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
                         null
                     },
                     onPress = {
-                        scale.animateTo(targetValue = 0.85f)
+                        scale.animateTo(targetValue = SCALE)
 
                         try {
                             awaitRelease()

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/PrivateSpaceScreen.kt
@@ -310,6 +310,14 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
 
     Column(
         modifier = modifier
+            .height(appDrawerRowsHeight)
+            .padding(appDrawerSettings.gridItemSettings.padding.dp)
+            .background(
+                color = Color(appDrawerSettings.gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(
+                    size = appDrawerSettings.gridItemSettings.cornerRadius.dp,
+                ),
+            )
             .pointerInput(key1 = isVisibleOverlay) {
                 detectTapGestures(
                     onTap = if (!isVisibleOverlay) {
@@ -356,13 +364,7 @@ internal fun PrivateSpaceEblanApplicationInfoItem(
                         }
                     },
                 )
-            }
-            .height(appDrawerRowsHeight)
-            .padding(appDrawerSettings.gridItemSettings.padding.dp)
-            .background(
-                color = Color(appDrawerSettings.gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = appDrawerSettings.gridItemSettings.cornerRadius.dp),
-            ),
+            },
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
     ) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -120,6 +120,7 @@ import com.eblan.launcher.feature.home.screen.application.handleDragEblanApplica
 import com.eblan.launcher.feature.home.screen.application.handleOnLongPressEblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.handleOnTapEblanApplicationInfoItem
 import com.eblan.launcher.feature.home.screen.application.rememberIsQuietModeEnabled
+import com.eblan.launcher.feature.home.util.SCALE
 import com.eblan.launcher.feature.home.util.getAppDrawerGridItemTextColor
 import com.eblan.launcher.ui.local.LocalLauncherApps
 import com.eblan.launcher.ui.local.LocalUserManager
@@ -853,7 +854,7 @@ private fun EblanApplicationInfoListItem(
                         null
                     },
                     onPress = {
-                        scale.animateTo(targetValue = 0.85f)
+                        scale.animateTo(targetValue = SCALE)
 
                         try {
                             awaitRelease()

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -17,9 +17,12 @@
  */
 package com.eblan.launcher.feature.home.screen.application.list
 
+import android.R.attr.scaleX
+import android.R.attr.scaleY
 import android.os.Build
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -67,6 +70,7 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -768,6 +772,14 @@ private fun EblanApplicationInfoListItem(
         parent = SharedElementKey.Parent.SwipeY,
     )
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     LaunchedEffect(
         key1 = drag,
         key2 = isLongPress,
@@ -834,6 +846,15 @@ private fun EblanApplicationInfoListItem(
                     } else {
                         null
                     },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
+                    },
                 )
             }
             .fillMaxWidth()
@@ -849,18 +870,15 @@ private fun EblanApplicationInfoListItem(
                 .data(eblanApplicationInfo.customIcon ?: icon)
                 .addLastModifiedToFileCacheKey(true).size(iconSizePx).crossfade(false).build(),
             contentDescription = null,
-            modifier = Modifier.size(appDrawerSettings.gridItemSettings.iconSize.dp).alpha(alpha)
-                .drawWithContent {
-                    graphicsLayer.record {
-                        this@drawWithContent.drawContent()
-                    }
-
-                    drawLayer(graphicsLayer)
-                }.onGloballyPositioned { layoutCoordinates ->
+            modifier = Modifier
+                .size(appDrawerSettings.gridItemSettings.iconSize.dp)
+                .alpha(alpha)
+                .onGloballyPositioned { layoutCoordinates ->
                     intOffset = layoutCoordinates.positionInRoot().round()
 
                     intSize = layoutCoordinates.size
-                }.run {
+                }
+                .run {
                     if (!isScrollInProgress && !isLongPress && !isVisibleOverlay) {
                         with(sharedTransitionScope) {
                             sharedElementWithCallerManagedVisibility(
@@ -873,6 +891,17 @@ private fun EblanApplicationInfoListItem(
                     } else {
                         this
                     }
+                }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                }
+                .drawWithContent {
+                    graphicsLayer.record {
+                        this@drawWithContent.drawContent()
+                    }
+
+                    drawLayer(graphicsLayer)
                 },
         )
 

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/ListApplicationScreen.kt
@@ -17,8 +17,6 @@
  */
 package com.eblan.launcher.feature.home.screen.application.list
 
-import android.R.attr.scaleX
-import android.R.attr.scaleY
 import android.os.Build
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
@@ -804,6 +802,14 @@ private fun EblanApplicationInfoListItem(
 
     Row(
         modifier = modifier
+            .fillMaxWidth()
+            .padding(10.dp)
+            .background(
+                color = Color(appDrawerSettings.gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(
+                    size = appDrawerSettings.gridItemSettings.cornerRadius.dp,
+                ),
+            )
             .pointerInput(key1 = isVisibleOverlay) {
                 detectTapGestures(
                     onTap = if (!isVisibleOverlay) {
@@ -856,13 +862,7 @@ private fun EblanApplicationInfoListItem(
                         }
                     },
                 )
-            }
-            .fillMaxWidth()
-            .padding(10.dp)
-            .background(
-                color = Color(appDrawerSettings.gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = appDrawerSettings.gridItemSettings.cornerRadius.dp),
-            ),
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(
@@ -872,11 +872,14 @@ private fun EblanApplicationInfoListItem(
             contentDescription = null,
             modifier = Modifier
                 .size(appDrawerSettings.gridItemSettings.iconSize.dp)
-                .alpha(alpha)
                 .onGloballyPositioned { layoutCoordinates ->
                     intOffset = layoutCoordinates.positionInRoot().round()
 
                     intSize = layoutCoordinates.size
+                }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
                 }
                 .run {
                     if (!isScrollInProgress && !isLongPress && !isVisibleOverlay) {
@@ -892,17 +895,14 @@ private fun EblanApplicationInfoListItem(
                         this
                     }
                 }
-                .graphicsLayer {
-                    scaleX = scale.value
-                    scaleY = scale.value
-                }
                 .drawWithContent {
                     graphicsLayer.record {
                         this@drawWithContent.drawContent()
                     }
 
                     drawLayer(graphicsLayer)
-                },
+                }
+                .alpha(alpha),
         )
 
         if (appDrawerSettings.gridItemSettings.showLabel) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
@@ -199,6 +199,14 @@ private fun PrivateSpaceEblanApplicationInfoItem(
 
     Row(
         modifier = modifier
+            .fillMaxWidth()
+            .padding(10.dp)
+            .background(
+                color = Color(appDrawerSettings.gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(
+                    size = appDrawerSettings.gridItemSettings.cornerRadius.dp,
+                ),
+            )
             .pointerInput(key1 = isVisibleOverlay) {
                 detectTapGestures(
                     onTap = if (!isVisibleOverlay) {
@@ -245,13 +253,7 @@ private fun PrivateSpaceEblanApplicationInfoItem(
                         }
                     },
                 )
-            }
-            .fillMaxWidth()
-            .padding(10.dp)
-            .background(
-                color = Color(appDrawerSettings.gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = appDrawerSettings.gridItemSettings.cornerRadius.dp),
-            ),
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/application/list/PrivateSpaceScreen.kt
@@ -18,6 +18,7 @@
 package com.eblan.launcher.feature.home.screen.application.list
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -33,6 +34,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,7 +43,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
@@ -187,6 +189,14 @@ private fun PrivateSpaceEblanApplicationInfoItem(
         appDrawerSettings.gridItemSettings.iconSize.dp.roundToPx()
     }
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     Row(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay) {
@@ -225,6 +235,15 @@ private fun PrivateSpaceEblanApplicationInfoItem(
                     } else {
                         null
                     },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
+                    },
                 )
             }
             .fillMaxWidth()
@@ -241,14 +260,16 @@ private fun PrivateSpaceEblanApplicationInfoItem(
                 .addLastModifiedToFileCacheKey(true).size(iconSizePx).crossfade(false).build(),
             contentDescription = null,
             modifier = Modifier
+                .size(appDrawerSettings.gridItemSettings.iconSize.dp)
                 .onGloballyPositioned { layoutCoordinates ->
                     intOffset = layoutCoordinates.positionInRoot().round()
 
                     intSize = layoutCoordinates.size
                 }
-                .size(appDrawerSettings.gridItemSettings.iconSize.dp),
-            placeholder = ColorPainter(Color.Transparent),
-            error = ColorPainter(Color.Transparent),
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                },
         )
 
         Spacer(modifier = Modifier.width(10.dp))

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -17,11 +17,14 @@
  */
 package com.eblan.launcher.feature.home.screen.folder
 
+import android.R.attr.scaleX
+import android.R.attr.scaleY
 import android.content.Intent.parseUri
 import android.graphics.Rect
 import android.os.Build
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -49,6 +52,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -358,6 +362,14 @@ private fun InteractiveFolderApplicationInfoGridItem(
 
     val isNotificationAccessGranted by rememberIsNotificationAccessGranted()
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     Column(
         modifier = modifier
             .pointerInput(
@@ -409,6 +421,15 @@ private fun InteractiveFolderApplicationInfoGridItem(
                     } else {
                         null
                     },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
+                    },
                 )
             }
             .swipeGestures(
@@ -455,6 +476,10 @@ private fun InteractiveFolderApplicationInfoGridItem(
                         } else {
                             this
                         }
+                    }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.record {
@@ -554,6 +579,14 @@ private fun InteractiveFolderShortcutInfoGridItem(
 
     val alpha = if (hasInteraction) 0f else defaultAlpha
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     Column(
         modifier = modifier
             .pointerInput(
@@ -613,6 +646,15 @@ private fun InteractiveFolderShortcutInfoGridItem(
                     } else {
                         null
                     },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
+                    },
                 )
             }
             .swipeGestures(
@@ -656,6 +698,10 @@ private fun InteractiveFolderShortcutInfoGridItem(
                         } else {
                             this
                         }
+                    }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.apply {
@@ -762,6 +808,14 @@ private fun InteractiveFolderShortcutConfigGridItem(
 
     val alpha = if (hasInteraction) 0f else 1f
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     Column(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay && !isInProgress) {
@@ -808,6 +862,15 @@ private fun InteractiveFolderShortcutConfigGridItem(
                     } else {
                         null
                     },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
+                    },
                 )
             }
             .swipeGestures(
@@ -849,6 +912,10 @@ private fun InteractiveFolderShortcutConfigGridItem(
                     } else {
                         this
                     }
+                }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
                 }
                 .drawWithContent {
                     graphicsLayer.record {
@@ -934,6 +1001,14 @@ private fun InteractiveNestedFolderGridItem(
 
     val alpha = if (hasInteraction) 0f else 1f
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     LaunchedEffect(
         key1 = drag,
         key2 = hasInteraction,
@@ -1002,6 +1077,15 @@ private fun InteractiveNestedFolderGridItem(
                     } else {
                         null
                     },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
+                    },
                 )
             }
             .swipeGestures(
@@ -1040,6 +1124,10 @@ private fun InteractiveNestedFolderGridItem(
                     } else {
                         this
                     }
+                }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
                 }
                 .drawWithContent {
                     graphicsLayer.record {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -87,6 +87,7 @@ import com.eblan.launcher.feature.home.component.PreviewFolderGridLayout
 import com.eblan.launcher.feature.home.component.swipeGestures
 import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.SharedElementKey
+import com.eblan.launcher.feature.home.util.SCALE
 import com.eblan.launcher.feature.home.util.getHorizontalAlignment
 import com.eblan.launcher.feature.home.util.getVerticalArrangement
 import com.eblan.launcher.feature.home.util.onDoubleTap
@@ -426,7 +427,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
                         null
                     },
                     onPress = {
-                        scale.animateTo(targetValue = 0.85f)
+                        scale.animateTo(targetValue = SCALE)
 
                         try {
                             awaitRelease()
@@ -868,7 +869,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
                         null
                     },
                     onPress = {
-                        scale.animateTo(targetValue = 0.85f)
+                        scale.animateTo(targetValue = SCALE)
 
                         try {
                             awaitRelease()

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -17,8 +17,6 @@
  */
 package com.eblan.launcher.feature.home.screen.folder
 
-import android.R.attr.scaleX
-import android.R.attr.scaleY
 import android.content.Intent.parseUri
 import android.graphics.Rect
 import android.os.Build
@@ -372,6 +370,12 @@ private fun InteractiveFolderApplicationInfoGridItem(
 
     Column(
         modifier = modifier
+            .fillMaxSize()
+            .padding(padding)
+            .background(
+                color = Color(gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
+            )
             .pointerInput(
                 key1 = isVisibleOverlay,
                 key2 = isInProgress,
@@ -437,12 +441,6 @@ private fun InteractiveFolderApplicationInfoGridItem(
                 swipeUp = gridItem.swipeUp,
                 enabled = !isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
-            )
-            .fillMaxSize()
-            .padding(padding)
-            .background(
-                color = Color(gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
             ),
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
@@ -463,6 +461,10 @@ private fun InteractiveFolderApplicationInfoGridItem(
 
                         intSize = layoutCoordinates.size
                     }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
+                    }
                     .run {
                         if (!isScrollInProgress && !hasInteraction && !isInProgress) {
                             with(sharedTransitionScope) {
@@ -476,10 +478,6 @@ private fun InteractiveFolderApplicationInfoGridItem(
                         } else {
                             this
                         }
-                    }
-                    .graphicsLayer {
-                        scaleX = scale.value
-                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.record {
@@ -589,6 +587,12 @@ private fun InteractiveFolderShortcutInfoGridItem(
 
     Column(
         modifier = modifier
+            .fillMaxSize()
+            .padding(padding)
+            .background(
+                color = Color(gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
+            )
             .pointerInput(
                 key1 = isVisibleOverlay,
                 key2 = isInProgress,
@@ -631,7 +635,8 @@ private fun InteractiveFolderShortcutInfoGridItem(
                     },
                     onTap = if (!isVisibleOverlay && !isInProgress) {
                         {
-                            if (hasShortcutHostPermission &&
+                            if (
+                                hasShortcutHostPermission &&
                                 data.isEnabled &&
                                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1
                             ) {
@@ -662,12 +667,6 @@ private fun InteractiveFolderShortcutInfoGridItem(
                 swipeUp = gridItem.swipeUp,
                 enabled = !isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
-            )
-            .fillMaxSize()
-            .padding(padding)
-            .background(
-                color = Color(gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
             ),
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
@@ -685,6 +684,10 @@ private fun InteractiveFolderShortcutInfoGridItem(
 
                         intSize = layoutCoordinates.size
                     }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
+                    }
                     .run {
                         if (!isScrollInProgress && !hasInteraction && !isInProgress) {
                             with(sharedTransitionScope) {
@@ -698,10 +701,6 @@ private fun InteractiveFolderShortcutInfoGridItem(
                         } else {
                             this
                         }
-                    }
-                    .graphicsLayer {
-                        scaleX = scale.value
-                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.apply {
@@ -818,6 +817,12 @@ private fun InteractiveFolderShortcutConfigGridItem(
 
     Column(
         modifier = modifier
+            .fillMaxSize()
+            .padding(padding)
+            .background(
+                color = Color(gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
+            )
             .pointerInput(key1 = isVisibleOverlay && !isInProgress) {
                 detectTapGestures(
                     onDoubleTap = if (!isVisibleOverlay && !isInProgress) {
@@ -878,12 +883,6 @@ private fun InteractiveFolderShortcutConfigGridItem(
                 swipeUp = gridItem.swipeUp,
                 enabled = !isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
-            )
-            .fillMaxSize()
-            .padding(padding)
-            .background(
-                color = Color(gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
             ),
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
@@ -899,6 +898,10 @@ private fun InteractiveFolderShortcutConfigGridItem(
 
                     intSize = layoutCoordinates.size
                 }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                }
                 .run {
                     if (!isScrollInProgress && !hasInteraction && !isInProgress) {
                         with(sharedTransitionScope) {
@@ -912,10 +915,6 @@ private fun InteractiveFolderShortcutConfigGridItem(
                     } else {
                         this
                     }
-                }
-                .graphicsLayer {
-                    scaleX = scale.value
-                    scaleY = scale.value
                 }
                 .drawWithContent {
                     graphicsLayer.record {
@@ -1023,6 +1022,12 @@ private fun InteractiveNestedFolderGridItem(
 
     Column(
         modifier = modifier
+            .fillMaxSize()
+            .padding(padding)
+            .background(
+                color = Color(gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
+            )
             .pointerInput(
                 key1 = isVisibleOverlay,
                 key2 = isInProgress,
@@ -1093,50 +1098,42 @@ private fun InteractiveNestedFolderGridItem(
                 swipeUp = gridItem.swipeUp,
                 enabled = !isInProgress,
                 onOpenAppDrawer = onOpenAppDrawer,
-            )
-            .fillMaxSize()
-            .padding(padding)
-            .background(
-                color = Color(gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
             ),
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
     ) {
-        val commonModifier =
-            Modifier
-                .size(iconSize)
-                .onGloballyPositioned { layoutCoordinates ->
-                    intOffset = layoutCoordinates.positionInRoot().round()
-
-                    intSize = layoutCoordinates.size
-                }
-                .run {
-                    if (!isScrollInProgress && !hasInteraction && !isInProgress) {
-                        with(sharedTransitionScope) {
-                            sharedElementWithCallerManagedVisibility(
-                                rememberSharedContentState(
-                                    key = sharedElementKey,
-                                ),
-                                visible = true,
-                            )
-                        }
-                    } else {
-                        this
+        val commonModifier = Modifier
+            .size(iconSize)
+            .onGloballyPositioned { layoutCoordinates ->
+                intOffset = layoutCoordinates.positionInRoot().round()
+                intSize = layoutCoordinates.size
+            }
+            .graphicsLayer {
+                scaleX = scale.value
+                scaleY = scale.value
+            }
+            .run {
+                if (!isScrollInProgress && !hasInteraction && !isInProgress) {
+                    with(sharedTransitionScope) {
+                        sharedElementWithCallerManagedVisibility(
+                            rememberSharedContentState(
+                                key = sharedElementKey,
+                            ),
+                            visible = true,
+                        )
                     }
+                } else {
+                    this
                 }
-                .graphicsLayer {
-                    scaleX = scale.value
-                    scaleY = scale.value
+            }
+            .drawWithContent {
+                graphicsLayer.record {
+                    this@drawWithContent.drawContent()
                 }
-                .drawWithContent {
-                    graphicsLayer.record {
-                        this@drawWithContent.drawContent()
-                    }
 
-                    drawLayer(graphicsLayer)
-                }
-                .alpha(alpha)
+                drawLayer(graphicsLayer)
+            }
+            .alpha(alpha)
 
         if (data.icon != null) {
             AsyncImage(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -83,6 +83,7 @@ import com.eblan.launcher.feature.home.component.whiteBox
 import com.eblan.launcher.feature.home.model.Drag
 import com.eblan.launcher.feature.home.model.GridItemSource
 import com.eblan.launcher.feature.home.model.SharedElementKey
+import com.eblan.launcher.feature.home.util.SCALE
 import com.eblan.launcher.feature.home.util.getGridItemTextColor
 import com.eblan.launcher.feature.home.util.getHorizontalAlignment
 import com.eblan.launcher.feature.home.util.getTextColor
@@ -469,7 +470,7 @@ private fun InteractiveApplicationInfoGridItem(
                         null
                     },
                     onPress = {
-                        scale.animateTo(targetValue = 0.85f)
+                        scale.animateTo(targetValue = SCALE)
 
                         try {
                             awaitRelease()
@@ -842,7 +843,7 @@ private fun InteractiveShortcutInfoGridItem(
                         null
                     },
                     onPress = {
-                        scale.animateTo(targetValue = 0.85f)
+                        scale.animateTo(targetValue = SCALE)
 
                         try {
                             awaitRelease()
@@ -1099,7 +1100,7 @@ private fun InteractiveFolderGridItem(
                         null
                     },
                     onPress = {
-                        scale.animateTo(targetValue = 0.85f)
+                        scale.animateTo(targetValue = SCALE)
 
                         try {
                             awaitRelease()
@@ -1334,7 +1335,7 @@ private fun InteractiveShortcutConfigGridItem(
                         null
                     },
                     onPress = {
-                        scale.animateTo(targetValue = 0.85f)
+                        scale.animateTo(targetValue = SCALE)
 
                         try {
                             awaitRelease()

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -411,6 +411,16 @@ private fun InteractiveApplicationInfoGridItem(
 
     Column(
         modifier = modifier
+            .fillMaxSize()
+            .padding(gridItemSettings.padding.dp)
+            .background(
+                color = Color(gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
+            )
+            .whiteBox(
+                textColor = textColor,
+                visible = isVisibleWhiteBox && !isVisibleFolder,
+            )
             .pointerInput(key1 = isVisibleOverlay) {
                 detectTapGestures(
                     onDoubleTap = if (!isVisibleOverlay) {
@@ -473,16 +483,6 @@ private fun InteractiveApplicationInfoGridItem(
                 swipeDown = gridItem.swipeDown,
                 swipeUp = gridItem.swipeUp,
                 onOpenAppDrawer = onOpenAppDrawer,
-            )
-            .fillMaxSize()
-            .padding(gridItemSettings.padding.dp)
-            .background(
-                color = Color(gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
-            )
-            .whiteBox(
-                textColor = textColor,
-                visible = isVisibleWhiteBox && !isVisibleFolder,
             ),
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
@@ -505,6 +505,10 @@ private fun InteractiveApplicationInfoGridItem(
 
                         intSize = layoutCoordinates.size
                     }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
+                    }
                     .run {
                         if (!isScrollInProgress && !hasInteraction) {
                             with(sharedTransitionScope) {
@@ -518,10 +522,6 @@ private fun InteractiveApplicationInfoGridItem(
                         } else {
                             this
                         }
-                    }
-                    .graphicsLayer {
-                        scaleX = scale.value
-                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.record {
@@ -611,7 +611,6 @@ private fun InteractiveWidgetGridItem(
             .matchParentSize()
             .onGloballyPositioned { layoutCoordinates ->
                 intOffset = layoutCoordinates.positionInRoot().round()
-
                 intSize = layoutCoordinates.size
             }
             .run {
@@ -778,6 +777,16 @@ private fun InteractiveShortcutInfoGridItem(
 
     Column(
         modifier = modifier
+            .fillMaxSize()
+            .padding(gridItemSettings.padding.dp)
+            .background(
+                color = Color(gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
+            )
+            .whiteBox(
+                textColor = textColor,
+                visible = isVisibleWhiteBox && !isVisibleFolder,
+            )
             .pointerInput(key1 = isVisibleOverlay) {
                 detectTapGestures(
                     onDoubleTap = if (!isVisibleOverlay) {
@@ -816,7 +825,8 @@ private fun InteractiveShortcutInfoGridItem(
                     },
                     onTap = if (!isVisibleOverlay) {
                         {
-                            if (hasShortcutHostPermission &&
+                            if (
+                                hasShortcutHostPermission &&
                                 data.isEnabled &&
                                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1
                             ) {
@@ -846,17 +856,6 @@ private fun InteractiveShortcutInfoGridItem(
                 swipeDown = gridItem.swipeDown,
                 swipeUp = gridItem.swipeUp,
                 onOpenAppDrawer = onOpenAppDrawer,
-            )
-            .fillMaxSize()
-            .padding(gridItemSettings.padding.dp)
-            .background(
-                color = Color(gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
-            )
-            .whiteBox(
-                textColor = textColor,
-
-                visible = isVisibleWhiteBox && !isVisibleFolder,
             ),
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
@@ -876,6 +875,10 @@ private fun InteractiveShortcutInfoGridItem(
 
                         intSize = layoutCoordinates.size
                     }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
+                    }
                     .run {
                         if (!isScrollInProgress && !hasInteraction) {
                             with(sharedTransitionScope) {
@@ -889,10 +892,6 @@ private fun InteractiveShortcutInfoGridItem(
                         } else {
                             this
                         }
-                    }
-                    .graphicsLayer {
-                        scaleX = scale.value
-                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.apply {
@@ -1035,6 +1034,16 @@ private fun InteractiveFolderGridItem(
 
     Column(
         modifier = modifier
+            .fillMaxSize()
+            .padding(gridItemSettings.padding.dp)
+            .background(
+                color = Color(gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
+            )
+            .whiteBox(
+                textColor = textColor,
+                visible = isVisibleWhiteBox && !isVisibleFolder,
+            )
             .pointerInput(key1 = isVisibleOverlay) {
                 detectTapGestures(
                     onDoubleTap = if (!isVisibleOverlay) {
@@ -1104,16 +1113,6 @@ private fun InteractiveFolderGridItem(
                 swipeDown = gridItem.swipeDown,
                 swipeUp = gridItem.swipeUp,
                 onOpenAppDrawer = onOpenAppDrawer,
-            )
-            .fillMaxSize()
-            .padding(gridItemSettings.padding.dp)
-            .background(
-                color = Color(gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
-            )
-            .whiteBox(
-                textColor = textColor,
-                visible = isVisibleWhiteBox && !isVisibleFolder,
             ),
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
@@ -1124,6 +1123,10 @@ private fun InteractiveFolderGridItem(
                 intOffset = layoutCoordinates.positionInRoot().round()
 
                 intSize = layoutCoordinates.size
+            }
+            .graphicsLayer {
+                scaleX = scale.value
+                scaleY = scale.value
             }
             .run {
                 if (!isScrollInProgress && !hasInteraction) {
@@ -1138,10 +1141,6 @@ private fun InteractiveFolderGridItem(
                 } else {
                     this
                 }
-            }
-            .graphicsLayer {
-                scaleX = scale.value
-                scaleY = scale.value
             }
             .drawWithContent {
                 graphicsLayer.record {
@@ -1279,6 +1278,16 @@ private fun InteractiveShortcutConfigGridItem(
 
     Column(
         modifier = modifier
+            .fillMaxSize()
+            .padding(gridItemSettings.padding.dp)
+            .background(
+                color = Color(gridItemSettings.customBackgroundColor),
+                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
+            )
+            .whiteBox(
+                textColor = textColor,
+                visible = isVisibleWhiteBox && !isVisibleFolder,
+            )
             .pointerInput(key1 = isVisibleOverlay) {
                 detectTapGestures(
                     onDoubleTap = if (!isVisibleOverlay) {
@@ -1339,16 +1348,6 @@ private fun InteractiveShortcutConfigGridItem(
                 swipeDown = gridItem.swipeDown,
                 swipeUp = gridItem.swipeUp,
                 onOpenAppDrawer = onOpenAppDrawer,
-            )
-            .fillMaxSize()
-            .padding(gridItemSettings.padding.dp)
-            .background(
-                color = Color(gridItemSettings.customBackgroundColor),
-                shape = RoundedCornerShape(size = gridItemSettings.cornerRadius.dp),
-            )
-            .whiteBox(
-                textColor = textColor,
-                visible = isVisibleWhiteBox && !isVisibleFolder,
             ),
         horizontalAlignment = horizontalAlignment,
         verticalArrangement = verticalArrangement,
@@ -1367,6 +1366,10 @@ private fun InteractiveShortcutConfigGridItem(
 
                     intSize = layoutCoordinates.size
                 }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                }
                 .run {
                     if (!isScrollInProgress && !hasInteraction) {
                         with(sharedTransitionScope) {
@@ -1380,10 +1383,6 @@ private fun InteractiveShortcutConfigGridItem(
                     } else {
                         this
                     }
-                }
-                .graphicsLayer {
-                    scaleX = scale.value
-                    scaleY = scale.value
                 }
                 .drawWithContent {
                     graphicsLayer.record {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -22,6 +22,7 @@ import android.graphics.Rect
 import android.os.Build
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -49,6 +50,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -168,6 +170,14 @@ internal fun InteractiveGridItem(
 
     val isVisibleWhiteBox = hasInteraction && drag == Drag.Dragging
 
+    val sourceBounds = getSourceBounds(
+        gridItem = gridItem,
+        cellWidth = cellWidth,
+        cellHeight = cellHeight,
+        leftPadding = leftPadding,
+        topOffset = topOffset,
+    )
+
     LaunchedEffect(
         key1 = drag,
         key2 = hasInteraction,
@@ -182,14 +192,6 @@ internal fun InteractiveGridItem(
             onUpdateIsCloseGridItemPopup(true)
         }
     }
-
-    val sourceBounds = getSourceBounds(
-        gridItem = gridItem,
-        cellWidth = cellWidth,
-        cellHeight = cellHeight,
-        leftPadding = leftPadding,
-        topOffset = topOffset,
-    )
 
     when (val data = gridItem.data) {
         is GridItemData.ApplicationInfo -> {
@@ -399,6 +401,14 @@ private fun InteractiveApplicationInfoGridItem(
 
     val isNotificationAccessGranted by rememberIsNotificationAccessGranted()
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     Column(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay) {
@@ -447,6 +457,15 @@ private fun InteractiveApplicationInfoGridItem(
                         }
                     } else {
                         null
+                    },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
                     },
                 )
             }
@@ -499,6 +518,10 @@ private fun InteractiveApplicationInfoGridItem(
                         } else {
                             this
                         }
+                    }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.record {
@@ -745,6 +768,14 @@ private fun InteractiveShortcutInfoGridItem(
 
     val alpha = if (hasInteraction) 0f else defaultAlpha
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     Column(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay) {
@@ -800,6 +831,15 @@ private fun InteractiveShortcutInfoGridItem(
                     } else {
                         null
                     },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
+                    },
                 )
             }
             .swipeGestures(
@@ -849,6 +889,10 @@ private fun InteractiveShortcutInfoGridItem(
                         } else {
                             this
                         }
+                    }
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
                     }
                     .drawWithContent {
                         graphicsLayer.apply {
@@ -964,6 +1008,14 @@ private fun InteractiveFolderGridItem(
     val currentFolderGridItems =
         rememberUpdatedState(previewFolderGridItems[gridItem.id]?.folderGridItems)
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     LaunchedEffect(key1 = moveGridItemResult) {
         handleConflictingGridItem(
             drag = currentDrag,
@@ -1037,6 +1089,15 @@ private fun InteractiveFolderGridItem(
                     } else {
                         null
                     },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
+                    },
                 )
             }
             .swipeGestures(
@@ -1077,6 +1138,10 @@ private fun InteractiveFolderGridItem(
                 } else {
                     this
                 }
+            }
+            .graphicsLayer {
+                scaleX = scale.value
+                scaleY = scale.value
             }
             .drawWithContent {
                 graphicsLayer.record {
@@ -1204,6 +1269,14 @@ private fun InteractiveShortcutConfigGridItem(
 
     val alpha = if (hasInteraction) 0f else 1f
 
+    val scale = remember { Animatable(1f) }
+
+    LaunchedEffect(key1 = isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            scale.snapTo(targetValue = 1f)
+        }
+    }
+
     Column(
         modifier = modifier
             .pointerInput(key1 = isVisibleOverlay) {
@@ -1250,6 +1323,15 @@ private fun InteractiveShortcutConfigGridItem(
                         }
                     } else {
                         null
+                    },
+                    onPress = {
+                        scale.animateTo(targetValue = 0.85f)
+
+                        try {
+                            awaitRelease()
+                        } finally {
+                            scale.animateTo(targetValue = 1f)
+                        }
                     },
                 )
             }
@@ -1298,6 +1380,10 @@ private fun InteractiveShortcutConfigGridItem(
                     } else {
                         this
                     }
+                }
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
                 }
                 .drawWithContent {
                     graphicsLayer.record {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/PagerScreen.kt
@@ -17,6 +17,8 @@
  */
 package com.eblan.launcher.feature.home.screen.pager
 
+import android.R.attr.scaleX
+import android.R.attr.scaleY
 import android.content.BroadcastReceiver
 import android.content.ClipDescription
 import android.content.Context
@@ -37,6 +39,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.draganddrop.dragAndDropTarget
@@ -73,6 +76,7 @@ import androidx.compose.ui.draganddrop.mimeTypes
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -125,6 +129,7 @@ import com.eblan.launcher.feature.home.screen.shortcutconfig.ShortcutConfigScree
 import com.eblan.launcher.feature.home.screen.widget.AppWidgetScreen
 import com.eblan.launcher.feature.home.screen.widget.WidgetScreen
 import com.eblan.launcher.feature.home.util.PAGE_INDICATOR_HEIGHT
+import com.eblan.launcher.feature.home.util.SCALE
 import com.eblan.launcher.feature.home.util.calculatePage
 import com.eblan.launcher.feature.home.util.getTextColor
 import com.eblan.launcher.framework.usermanager.AndroidUserManagerWrapper
@@ -1224,8 +1229,12 @@ private fun SharedTransitionScope.OverlayImage(
         DpSize(width = overlayIntSize.width.toDp(), height = overlayIntSize.height.toDp())
     }
 
+    val overlayScale = remember { Animatable(SCALE) }
+
     LaunchedEffect(key1 = isVisibleOverlay) {
-        if (!isVisibleOverlay) {
+        if (isVisibleOverlay) {
+            overlayScale.animateTo(targetValue = 1f)
+        } else {
             onResetOverlay()
         }
     }
@@ -1246,7 +1255,11 @@ private fun SharedTransitionScope.OverlayImage(
             .sharedElementWithCallerManagedVisibility(
                 rememberSharedContentState(key = sharedElementKey),
                 visible = isVisibleOverlay,
-            ),
+            )
+            .graphicsLayer {
+                scaleX = overlayScale.value
+                scaleY = overlayScale.value
+            },
         bitmap = overlayImageBitmap,
         contentDescription = null,
     )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
@@ -475,6 +475,8 @@ private fun EblanShortcutConfigItem(
 
     Column(
         modifier = modifier
+            .fillMaxWidth()
+            .padding(20.dp)
             .pointerInput(key1 = drag) {
                 detectTapGestures(
                     onLongPress = {
@@ -498,9 +500,7 @@ private fun EblanShortcutConfigItem(
                         }
                     },
                 )
-            }
-            .fillMaxWidth()
-            .padding(20.dp),
+            },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutconfig/ShortcutConfigScreen.kt
@@ -291,7 +291,10 @@ private fun EblanShortcutConfigsPage(
     paddingValues: PaddingValues,
     swipeY: Float,
     onDragEnd: () -> Unit,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+    ) -> Unit,
     onVerticalDrag: (Float) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     onUpdateGridItemSource: (GridItemSource) -> Unit,
@@ -538,7 +541,10 @@ private suspend fun handleOnLongPress(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     graphicsLayer: GraphicsLayer,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+    ) -> Unit,
     intOffset: IntOffset,
     intSize: IntSize,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutinfo/ShortcutInfoScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutinfo/ShortcutInfoScreen.kt
@@ -190,6 +190,11 @@ private fun ShortcutInfoMenuItem(
         leadingContent = {
             Box(
                 modifier = Modifier
+                    .size(30.dp)
+                    .onGloballyPositioned { layoutCoordinates ->
+                        intOffset = layoutCoordinates.positionInRoot().round()
+                        intSize = layoutCoordinates.size
+                    }
                     .drawWithContent {
                         graphicsLayer.record {
                             this@drawWithContent.drawContent()
@@ -220,13 +225,7 @@ private fun ShortcutInfoMenuItem(
                                 }
                             },
                         )
-                    }
-                    .onGloballyPositioned { layoutCoordinates ->
-                        intOffset = layoutCoordinates.positionInRoot().round()
-
-                        intSize = layoutCoordinates.size
-                    }
-                    .size(30.dp),
+                    },
             ) {
                 if (!isLongPress) {
                     AsyncImage(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutinfo/ShortcutInfoScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/shortcutinfo/ShortcutInfoScreen.kt
@@ -249,7 +249,10 @@ private suspend fun handleOnLongPress(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     graphicsLayer: GraphicsLayer,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+    ) -> Unit,
     intOffset: IntOffset,
     intSize: IntSize,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/AppWidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/AppWidgetScreen.kt
@@ -339,7 +339,10 @@ private suspend fun handleOnLongPress(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     graphicsLayer: GraphicsLayer,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+    ) -> Unit,
     intOffset: IntOffset,
     intSize: IntSize,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/AppWidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/AppWidgetScreen.kt
@@ -234,6 +234,8 @@ private fun EblanAppWidgetProviderInfoItem(
 
     Column(
         modifier = modifier
+            .size(200.dp)
+            .padding(20.dp)
             .pointerInput(key1 = drag) {
                 detectTapGestures(
                     onLongPress = {
@@ -258,9 +260,7 @@ private fun EblanAppWidgetProviderInfoItem(
                         }
                     },
                 )
-            }
-            .size(200.dp)
-            .padding(20.dp),
+            },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
@@ -471,7 +471,10 @@ private suspend fun handleOnLongPress(
     onUpdateMoveGridItemResult: (MoveGridItemResult) -> Unit,
     onUpdateImageBitmap: (ImageBitmap) -> Unit,
     graphicsLayer: GraphicsLayer,
-    onUpdateOverlayBounds: (IntOffset, IntSize) -> Unit,
+    onUpdateOverlayBounds: (
+        intOffset: IntOffset,
+        intSize: IntSize,
+    ) -> Unit,
     intOffset: IntOffset,
     intSize: IntSize,
     onUpdateSharedElementKey: (SharedElementKey?) -> Unit,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/widget/WidgetScreen.kt
@@ -360,6 +360,8 @@ private fun EblanAppWidgetProviderInfoItem(
 
     Column(
         modifier = modifier
+            .fillMaxWidth()
+            .padding(20.dp)
             .pointerInput(key1 = drag) {
                 detectTapGestures(
                     onLongPress = {
@@ -383,9 +385,7 @@ private fun EblanAppWidgetProviderInfoItem(
                         }
                     },
                 )
-            }
-            .fillMaxWidth()
-            .padding(20.dp),
+            },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/util/HomeUtil.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/util/HomeUtil.kt
@@ -184,3 +184,4 @@ internal fun updateAppWidgetOptions(
 
 internal val PAGE_INDICATOR_HEIGHT = 30.dp
 internal val DRAG_HANDLE_SIZE = 30.dp
+internal val SCALE = 0.85f


### PR DESCRIPTION
Closes #980 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subtle press feedback across app, folder, shortcut, widget, and pager items, scaling icons to 85% while pressed and restoring them on release.
  * Added a smooth scale-in animation for drag-and-drop overlay images.
* **Bug Fixes**
  * Improved overlay state handling so item and overlay scales reset correctly when overlays appear or disappear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->