### PR TITLE
Stale PagerScreenState After Settings Changed

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Modifier.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Modifier.kt
@@ -23,8 +23,10 @@ import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.graphicsLayer
@@ -58,6 +60,8 @@ internal fun Modifier.swipeGestures(
     val scope = rememberCoroutineScope()
 
     val launcherApps = LocalLauncherApps.current
+
+    val currentOnOpenAppDrawer by rememberUpdatedState(onOpenAppDrawer)
 
     return if ((
             swipeUp.eblanActionType != EblanActionType.None ||
@@ -99,7 +103,7 @@ internal fun Modifier.swipeGestures(
                                     context = context,
                                     eblanAction = swipeUp,
                                     launcherApps = launcherApps,
-                                    onOpenAppDrawer = onOpenAppDrawer,
+                                    onOpenAppDrawer = currentOnOpenAppDrawer,
                                 )
                             }
 
@@ -108,7 +112,7 @@ internal fun Modifier.swipeGestures(
                                     context = context,
                                     eblanAction = swipeDown,
                                     launcherApps = launcherApps,
-                                    onOpenAppDrawer = onOpenAppDrawer,
+                                    onOpenAppDrawer = currentOnOpenAppDrawer,
                                 )
                             }
                         }

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/InteractiveFolderGridItem.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -378,6 +379,12 @@ private fun InteractiveFolderApplicationInfoGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentOnOpenAppDrawer by rememberUpdatedState(onOpenAppDrawer)
+    val currentOnShowGridItemPopup by rememberUpdatedState(onShowGridItemPopup)
+    val currentOnUpdateImageBitmap by rememberUpdatedState(onUpdateImageBitmap)
+    val currentOnUpdateOverlayBounds by rememberUpdatedState(onUpdateOverlayBounds)
+    val currentOnUpdateSharedElementKey by rememberUpdatedState(onUpdateSharedElementKey)
+
     LaunchedEffect(
         key1 = isVisibleOverlay,
         key2 = animations,
@@ -406,7 +413,7 @@ private fun InteractiveFolderApplicationInfoGridItem(
                                 context = context,
                                 doubleTap = gridItem.doubleTap,
                                 launcherApps = launcherApps,
-                                onOpenAppDrawer = onOpenAppDrawer,
+                                onOpenAppDrawer = currentOnOpenAppDrawer,
                             )
                         }
                     } else {
@@ -421,10 +428,10 @@ private fun InteractiveFolderApplicationInfoGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
-                                    onUpdateImageBitmap = onUpdateImageBitmap,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
-                                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                                    onShowGridItemPopup = onShowGridItemPopup,
+                                    onUpdateImageBitmap = currentOnUpdateImageBitmap,
+                                    onUpdateOverlayBounds = currentOnUpdateOverlayBounds,
+                                    onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+                                    onShowGridItemPopup = currentOnShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                                 )
@@ -579,6 +586,12 @@ private fun InteractiveFolderShortcutInfoGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentOnOpenAppDrawer by rememberUpdatedState(onOpenAppDrawer)
+    val currentOnShowGridItemPopup by rememberUpdatedState(onShowGridItemPopup)
+    val currentOnUpdateImageBitmap by rememberUpdatedState(onUpdateImageBitmap)
+    val currentOnUpdateOverlayBounds by rememberUpdatedState(onUpdateOverlayBounds)
+    val currentOnUpdateSharedElementKey by rememberUpdatedState(onUpdateSharedElementKey)
+
     LaunchedEffect(
         key1 = isVisibleOverlay,
         key2 = animations,
@@ -608,7 +621,7 @@ private fun InteractiveFolderShortcutInfoGridItem(
                                     context = context,
                                     doubleTap = gridItem.doubleTap,
                                     launcherApps = launcherApps,
-                                    onOpenAppDrawer = onOpenAppDrawer,
+                                    onOpenAppDrawer = currentOnOpenAppDrawer,
                                 )
                             }
                         }
@@ -624,10 +637,10 @@ private fun InteractiveFolderShortcutInfoGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
-                                    onUpdateImageBitmap = onUpdateImageBitmap,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
-                                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                                    onShowGridItemPopup = onShowGridItemPopup,
+                                    onUpdateImageBitmap = currentOnUpdateImageBitmap,
+                                    onUpdateOverlayBounds = currentOnUpdateOverlayBounds,
+                                    onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+                                    onShowGridItemPopup = currentOnShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                                 )
@@ -790,6 +803,12 @@ private fun InteractiveFolderShortcutConfigGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentOnOpenAppDrawer by rememberUpdatedState(onOpenAppDrawer)
+    val currentOnShowGridItemPopup by rememberUpdatedState(onShowGridItemPopup)
+    val currentOnUpdateImageBitmap by rememberUpdatedState(onUpdateImageBitmap)
+    val currentOnUpdateOverlayBounds by rememberUpdatedState(onUpdateOverlayBounds)
+    val currentOnUpdateSharedElementKey by rememberUpdatedState(onUpdateSharedElementKey)
+
     LaunchedEffect(
         key1 = isVisibleOverlay,
         key2 = animations,
@@ -815,7 +834,7 @@ private fun InteractiveFolderShortcutConfigGridItem(
                                 context = context,
                                 doubleTap = gridItem.doubleTap,
                                 launcherApps = launcherApps,
-                                onOpenAppDrawer = onOpenAppDrawer,
+                                onOpenAppDrawer = currentOnOpenAppDrawer,
                             )
                         }
                     } else {
@@ -830,10 +849,10 @@ private fun InteractiveFolderShortcutConfigGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
-                                    onUpdateImageBitmap = onUpdateImageBitmap,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
-                                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                                    onShowGridItemPopup = onShowGridItemPopup,
+                                    onUpdateImageBitmap = currentOnUpdateImageBitmap,
+                                    onUpdateOverlayBounds = currentOnUpdateOverlayBounds,
+                                    onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+                                    onShowGridItemPopup = currentOnShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                                 )
@@ -967,6 +986,13 @@ private fun InteractiveNestedFolderGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentOnOpenAppDrawer by rememberUpdatedState(onOpenAppDrawer)
+    val currentOnShowGridItemPopup by rememberUpdatedState(onShowGridItemPopup)
+    val currentOnUpdateImageBitmap by rememberUpdatedState(onUpdateImageBitmap)
+    val currentOnUpdateIsDragging by rememberUpdatedState(onUpdateIsDragging)
+    val currentOnUpdateOverlayBounds by rememberUpdatedState(onUpdateOverlayBounds)
+    val currentOnUpdateSharedElementKey by rememberUpdatedState(onUpdateSharedElementKey)
+
     LaunchedEffect(
         key1 = isVisibleOverlay,
         key2 = animations,
@@ -982,7 +1008,7 @@ private fun InteractiveNestedFolderGridItem(
         key3 = showFolderGridItemPopup,
     ) {
         if (drag == Drag.Dragging && hasInteraction && showFolderGridItemPopup) {
-            onUpdateIsDragging(true)
+            currentOnUpdateIsDragging(true)
 
             onUpdateIsCloseFolderGridItemPopup(true)
         }
@@ -1007,7 +1033,7 @@ private fun InteractiveNestedFolderGridItem(
                                 context = context,
                                 doubleTap = gridItem.doubleTap,
                                 launcherApps = launcherApps,
-                                onOpenAppDrawer = onOpenAppDrawer,
+                                onOpenAppDrawer = currentOnOpenAppDrawer,
                             )
                         }
                     } else {
@@ -1022,10 +1048,10 @@ private fun InteractiveNestedFolderGridItem(
                                     intSize = intSize,
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
-                                    onUpdateImageBitmap = onUpdateImageBitmap,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
-                                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                                    onShowGridItemPopup = onShowGridItemPopup,
+                                    onUpdateImageBitmap = currentOnUpdateImageBitmap,
+                                    onUpdateOverlayBounds = currentOnUpdateOverlayBounds,
+                                    onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+                                    onShowGridItemPopup = currentOnShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                                 )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -403,9 +403,9 @@ private fun InteractiveApplicationInfoGridItem(
 
     val hasNotifications =
         statusBarNotifications[data.packageName] != null && (
-                statusBarNotifications[data.packageName]
-                    ?: 0
-                ) > 0
+            statusBarNotifications[data.packageName]
+                ?: 0
+            ) > 0
 
     val alpha = if (hasInteraction) 0f else 1f
 
@@ -1415,7 +1415,7 @@ private fun PreviewFolderGridItem(
             is GridItemData.Folder,
             is GridItemData.ShortcutConfig,
             is GridItemData.Widget,
-                -> if (hasInteraction) 0f else 1f
+            -> if (hasInteraction) 0f else 1f
 
             is GridItemData.ShortcutInfo -> {
                 if (hasInteraction) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -403,9 +403,9 @@ private fun InteractiveApplicationInfoGridItem(
 
     val hasNotifications =
         statusBarNotifications[data.packageName] != null && (
-            statusBarNotifications[data.packageName]
-                ?: 0
-            ) > 0
+                statusBarNotifications[data.packageName]
+                    ?: 0
+                ) > 0
 
     val alpha = if (hasInteraction) 0f else 1f
 
@@ -1126,34 +1126,30 @@ private fun InteractiveFolderGridItem(
                 modifier = commonModifier,
             )
         } else {
-            Box(
+            PreviewFolderGridLayout(
                 modifier = commonModifier.background(
                     color = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
                     shape = RoundedCornerShape(5.dp),
                 ),
-            ) {
-                PreviewFolderGridLayout(
-                    modifier = Modifier.matchParentSize(),
-                    gridItems = previewFolderGridItems[gridItem.id]?.previewFolderGridItems,
-                    content = {
-                        PreviewFolderGridItem(
-                            sharedTransitionScope = sharedTransitionScope,
-                            gridItem = it,
-                            isScrollInProgress = isScrollInProgress,
-                            isVisibleOverlay = isVisibleOverlay,
-                            parent = sharedElementKey.parent,
-                            moveGridItemResult = moveGridItemResult,
-                            textColor = textColor,
-                            drag = drag,
-                            folderGridItems = previewFolderGridItems[gridItem.id]?.folderGridItems,
-                            isVisibleFolder = isVisibleFolder,
-                            hasShortcutHostPermission = hasShortcutHostPermission,
-                            iconPackInfoFilePaths = iconPackInfoFilePaths,
-                            onResetGrid = onResetGrid,
-                        )
-                    },
-                )
-            }
+                gridItems = previewFolderGridItems[gridItem.id]?.previewFolderGridItems,
+                content = {
+                    PreviewFolderGridItem(
+                        sharedTransitionScope = sharedTransitionScope,
+                        gridItem = it,
+                        isScrollInProgress = isScrollInProgress,
+                        isVisibleOverlay = isVisibleOverlay,
+                        parent = sharedElementKey.parent,
+                        moveGridItemResult = moveGridItemResult,
+                        textColor = textColor,
+                        drag = drag,
+                        folderGridItems = previewFolderGridItems[gridItem.id]?.folderGridItems,
+                        isVisibleFolder = isVisibleFolder,
+                        hasShortcutHostPermission = hasShortcutHostPermission,
+                        iconPackInfoFilePaths = iconPackInfoFilePaths,
+                        onResetGrid = onResetGrid,
+                    )
+                },
+            )
         }
 
         if (gridItemSettings.showLabel) {
@@ -1390,7 +1386,7 @@ private fun PreviewFolderGridItem(
             is GridItemData.Folder,
             is GridItemData.ShortcutConfig,
             is GridItemData.Widget,
-            -> if (hasInteraction) 0f else 1f
+                -> if (hasInteraction) 0f else 1f
 
             is GridItemData.ShortcutInfo -> {
                 if (hasInteraction) {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/pager/InteractiveGridItem.kt
@@ -413,6 +413,12 @@ private fun InteractiveApplicationInfoGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentOnOpenAppDrawer by rememberUpdatedState(onOpenAppDrawer)
+    val currentOnShowGridItemPopup by rememberUpdatedState(onShowGridItemPopup)
+    val currentOnUpdateImageBitmap by rememberUpdatedState(onUpdateImageBitmap)
+    val currentOnUpdateOverlayBounds by rememberUpdatedState(onUpdateOverlayBounds)
+    val currentOnUpdateSharedElementKey by rememberUpdatedState(onUpdateSharedElementKey)
+
     LaunchedEffect(
         key1 = isVisibleOverlay,
         key2 = animations,
@@ -442,7 +448,7 @@ private fun InteractiveApplicationInfoGridItem(
                                 context = context,
                                 doubleTap = gridItem.doubleTap,
                                 launcherApps = launcherApps,
-                                onOpenAppDrawer = onOpenAppDrawer,
+                                onOpenAppDrawer = currentOnOpenAppDrawer,
                             )
                         }
                     } else {
@@ -458,10 +464,10 @@ private fun InteractiveApplicationInfoGridItem(
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
                                     onUpdateGridItemSource = onUpdateGridItemSource,
-                                    onUpdateImageBitmap = onUpdateImageBitmap,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
-                                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                                    onShowGridItemPopup = onShowGridItemPopup,
+                                    onUpdateImageBitmap = currentOnUpdateImageBitmap,
+                                    onUpdateOverlayBounds = currentOnUpdateOverlayBounds,
+                                    onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+                                    onShowGridItemPopup = currentOnShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                                 )
@@ -598,6 +604,11 @@ private fun InteractiveWidgetGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentOnShowGridItemPopup by rememberUpdatedState(onShowGridItemPopup)
+    val currentOnUpdateImageBitmap by rememberUpdatedState(onUpdateImageBitmap)
+    val currentOnUpdateOverlayBounds by rememberUpdatedState(onUpdateOverlayBounds)
+    val currentOnUpdateSharedElementKey by rememberUpdatedState(onUpdateSharedElementKey)
+
     LaunchedEffect(
         key1 = isVisibleOverlay,
         key2 = animations,
@@ -653,10 +664,10 @@ private fun InteractiveWidgetGridItem(
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
                                     onUpdateGridItemSource = onUpdateGridItemSource,
-                                    onUpdateImageBitmap = onUpdateImageBitmap,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
-                                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                                    onShowGridItemPopup = onShowGridItemPopup,
+                                    onUpdateImageBitmap = currentOnUpdateImageBitmap,
+                                    onUpdateOverlayBounds = currentOnUpdateOverlayBounds,
+                                    onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+                                    onShowGridItemPopup = currentOnShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                                 )
@@ -683,10 +694,10 @@ private fun InteractiveWidgetGridItem(
                                         sharedElementKey = sharedElementKey,
                                         gridItem = gridItem,
                                         onUpdateGridItemSource = onUpdateGridItemSource,
-                                        onUpdateImageBitmap = onUpdateImageBitmap,
-                                        onUpdateOverlayBounds = onUpdateOverlayBounds,
-                                        onUpdateSharedElementKey = onUpdateSharedElementKey,
-                                        onShowGridItemPopup = onShowGridItemPopup,
+                                        onUpdateImageBitmap = currentOnUpdateImageBitmap,
+                                        onUpdateOverlayBounds = currentOnUpdateOverlayBounds,
+                                        onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+                                        onShowGridItemPopup = currentOnShowGridItemPopup,
                                         onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                         onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                                     )
@@ -773,6 +784,12 @@ private fun InteractiveShortcutInfoGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentOnOpenAppDrawer by rememberUpdatedState(onOpenAppDrawer)
+    val currentOnShowGridItemPopup by rememberUpdatedState(onShowGridItemPopup)
+    val currentOnUpdateImageBitmap by rememberUpdatedState(onUpdateImageBitmap)
+    val currentOnUpdateOverlayBounds by rememberUpdatedState(onUpdateOverlayBounds)
+    val currentOnUpdateSharedElementKey by rememberUpdatedState(onUpdateSharedElementKey)
+
     LaunchedEffect(
         key1 = isVisibleOverlay,
         key2 = animations,
@@ -802,7 +819,7 @@ private fun InteractiveShortcutInfoGridItem(
                                 context = context,
                                 doubleTap = gridItem.doubleTap,
                                 launcherApps = launcherApps,
-                                onOpenAppDrawer = onOpenAppDrawer,
+                                onOpenAppDrawer = currentOnOpenAppDrawer,
                             )
                         }
                     } else {
@@ -818,10 +835,10 @@ private fun InteractiveShortcutInfoGridItem(
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
                                     onUpdateGridItemSource = onUpdateGridItemSource,
-                                    onUpdateImageBitmap = onUpdateImageBitmap,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
-                                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                                    onShowGridItemPopup = onShowGridItemPopup,
+                                    onUpdateImageBitmap = currentOnUpdateImageBitmap,
+                                    onUpdateOverlayBounds = currentOnUpdateOverlayBounds,
+                                    onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+                                    onShowGridItemPopup = currentOnShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                                 )
@@ -991,6 +1008,12 @@ private fun InteractiveFolderGridItem(
     val currentLockMovement = rememberUpdatedState(lockMovement)
     val currentFolderGridItems =
         rememberUpdatedState(previewFolderGridItems[gridItem.id]?.folderGridItems)
+    val currentOnOpenAppDrawer by rememberUpdatedState(onOpenAppDrawer)
+    val currentOnShowGridItemPopup by rememberUpdatedState(onShowGridItemPopup)
+    val currentOnUpdateImageBitmap by rememberUpdatedState(onUpdateImageBitmap)
+    val currentOnUpdateOverlayBounds by rememberUpdatedState(onUpdateOverlayBounds)
+    val currentOnUpdateSharedElementKey by rememberUpdatedState(onUpdateSharedElementKey)
+    val currentOnUpdateIsVisibleFolder by rememberUpdatedState(onUpdateIsVisibleFolder)
 
     val scale = remember { Animatable(1f) }
 
@@ -1015,8 +1038,8 @@ private fun InteractiveFolderGridItem(
             gridItem = currentGridItem,
             folderGridItems = currentFolderGridItems,
             onShowFolderWhenDragging = onShowFolderWhenDragging,
-            onUpdateSharedElementKey = onUpdateSharedElementKey,
-            onUpdateIsVisibleFolder = onUpdateIsVisibleFolder,
+            onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+            onUpdateIsVisibleFolder = currentOnUpdateIsVisibleFolder,
         )
     }
 
@@ -1040,7 +1063,7 @@ private fun InteractiveFolderGridItem(
                                 context = context,
                                 doubleTap = gridItem.doubleTap,
                                 launcherApps = launcherApps,
-                                onOpenAppDrawer = onOpenAppDrawer,
+                                onOpenAppDrawer = currentOnOpenAppDrawer,
                             )
                         }
                     } else {
@@ -1056,10 +1079,10 @@ private fun InteractiveFolderGridItem(
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
                                     onUpdateGridItemSource = onUpdateGridItemSource,
-                                    onUpdateImageBitmap = onUpdateImageBitmap,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
-                                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                                    onShowGridItemPopup = onShowGridItemPopup,
+                                    onUpdateImageBitmap = currentOnUpdateImageBitmap,
+                                    onUpdateOverlayBounds = currentOnUpdateOverlayBounds,
+                                    onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+                                    onShowGridItemPopup = currentOnShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                                 )
@@ -1070,7 +1093,7 @@ private fun InteractiveFolderGridItem(
                     },
                     onTap = if (!isVisibleOverlay) {
                         {
-                            onUpdateIsVisibleFolder(true)
+                            currentOnUpdateIsVisibleFolder(true)
 
                             onUpsertFolderPopupEntry(
                                 FolderPopupEntry(
@@ -1235,6 +1258,12 @@ private fun InteractiveShortcutConfigGridItem(
 
     val scale = remember { Animatable(1f) }
 
+    val currentOnOpenAppDrawer by rememberUpdatedState(onOpenAppDrawer)
+    val currentOnShowGridItemPopup by rememberUpdatedState(onShowGridItemPopup)
+    val currentOnUpdateImageBitmap by rememberUpdatedState(onUpdateImageBitmap)
+    val currentOnUpdateOverlayBounds by rememberUpdatedState(onUpdateOverlayBounds)
+    val currentOnUpdateSharedElementKey by rememberUpdatedState(onUpdateSharedElementKey)
+
     LaunchedEffect(
         key1 = isVisibleOverlay,
         key2 = animations,
@@ -1264,7 +1293,7 @@ private fun InteractiveShortcutConfigGridItem(
                                 context = context,
                                 doubleTap = gridItem.doubleTap,
                                 launcherApps = launcherApps,
-                                onOpenAppDrawer = onOpenAppDrawer,
+                                onOpenAppDrawer = currentOnOpenAppDrawer,
                             )
                         }
                     } else {
@@ -1280,10 +1309,10 @@ private fun InteractiveShortcutConfigGridItem(
                                     sharedElementKey = sharedElementKey,
                                     gridItem = gridItem,
                                     onUpdateGridItemSource = onUpdateGridItemSource,
-                                    onUpdateImageBitmap = onUpdateImageBitmap,
-                                    onUpdateOverlayBounds = onUpdateOverlayBounds,
-                                    onUpdateSharedElementKey = onUpdateSharedElementKey,
-                                    onShowGridItemPopup = onShowGridItemPopup,
+                                    onUpdateImageBitmap = currentOnUpdateImageBitmap,
+                                    onUpdateOverlayBounds = currentOnUpdateOverlayBounds,
+                                    onUpdateSharedElementKey = currentOnUpdateSharedElementKey,
+                                    onShowGridItemPopup = currentOnShowGridItemPopup,
                                     onUpdateIsVisibleOverlay = onUpdateIsVisibleOverlay,
                                     onUpdateMoveGridItemResult = onUpdateMoveGridItemResult,
                                 )
@@ -1373,9 +1402,9 @@ private fun PreviewFolderGridItem(
     iconPackInfoFilePaths: Map<String, String?>,
     onResetGrid: () -> Unit,
 ) {
-    val context = LocalContext.current
-
     key(gridItem.id) {
+        val context = LocalContext.current
+
         val isSelected =
             moveGridItemResult != null && moveGridItemResult.movingGridItem.id == gridItem.id
 


### PR DESCRIPTION
Fixes #987

When Settings are updated, PagerScreenState recalculates itself and returns a new instance but we pass its callbacks to composable where they referenced old callbacks especially when inside a scope.

We use rememberUpdatedState to capture the latest callback reference from PagerScreenState.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture interactions so they consistently use the latest available actions and callbacks.
  * Fixed stale callback behavior during app, widget, shortcut, and folder interactions.
  * Improved nested-folder dragging and folder visibility updates.
  * Refined folder preview rendering for more consistent layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->