### PR TITLE
Translation: Czech

### DIFF
--- a/app/src/debug/res/values-cs/strings.xml
+++ b/app/src/debug/res/values-cs/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="app_name">Ladění Yagni spouštěče</string>
+</resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="app_name">Yagni spouštěč</string>
+    <string name="action_name">Akce Yagni</string>
+</resources>

--- a/common/src/main/res/values-cs/strings.xml
+++ b/common/src/main/res/values-cs/strings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="save">Uložit</string>
+    <string name="settings">Nastavení</string>
+    <string name="experimental">Experimentální</string>
+    <string name="custom_label">Vlastní název</string>
+    <string name="background_color">Barva pozadí</string>
+    <string name="gestures">Gesta</string>
+    <string name="columns_is_not_valid">Počet sloupců není platný</string>
+    <string name="grid">Mřížka</string>
+    <string name="columns">Sloupců</string>
+    <string name="update">Použít</string>
+    <string name="none">Nic</string>
+    <string name="home">Domovská obrazovka</string>
+    <string name="general">Obecné</string>
+    <string name="system">Systémové</string>
+    <string name="edit">Upravit %1$s</string>
+    <string name="add">Přidat</string>
+    <string name="okay">Budiž</string>
+    <string name="custom_label_is_not_valid">Vlastní název není platný</string>
+    <string name="rows_is_not_valid">Počet řádků není platný</string>
+    <string name="search_applications">Hledat aplikace</string>
+    <string name="dark">Tmavé</string>
+    <string name="app_drawer">Nabídka aplikací</string>
+    <string name="rows">Řádků</string>
+    <string name="light">Světlé</string>
+    <string name="cancel">Storno</string>
+</resources>

--- a/feature/action/src/main/res/values-cs/strings.xml
+++ b/feature/action/src/main/res/values-cs/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="yagni_launcher_action">Akce Yagni spouštěče</string>
+</resources>

--- a/feature/edit-application-info/src/main/res/values-cs/strings.xml
+++ b/feature/edit-application-info/src/main/res/values-cs/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="add_tag">Přidat štítek</string>
+    <string name="tag_is_not_valid">Štítek není platný</string>
+    <string name="update_tag">Použít štítek</string>
+    <string name="hide_from_drawer">Skrýt z nabídky</string>
+    <string name="view_hidden_apps_in_app_drawer_settings">Zobrazit skryté aplikace v nastavení nabídky aplikací</string>
+</resources>

--- a/feature/edit-grid-item/src/main/res/values-cs/strings.xml
+++ b/feature/edit-grid-item/src/main/res/values-cs/strings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="label">Název</string>
+    <string name="label_is_not_valid">Název není platný</string>
+    <string name="custom_short_label">Vlastní krátký název</string>
+    <string name="grid_item_actions">Akce položky mřížky</string>
+    <string name="override">Přepsat</string>
+    <string name="override_the_grid_item_settings">Přepsat nastavení položky mřížky</string>
+    <string name="edit_label">Upravit název</string>
+</resources>

--- a/feature/home/src/main/res/values-cs/strings.xml
+++ b/feature/home/src/main/res/values-cs/strings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="personal">Osobní</string>
+    <string name="clone">Klonované</string>
+    <string name="work">Pracovní</string>
+    <string name="sort_applications">Seřadit aplikace</string>
+    <string name="rearrange_applications">Přeuspořádat aplikace</string>
+    <string name="drag_an_item_to_rearrange">Přetažením položky ji přeuspořádáte</string>
+    <string name="work_apps_are_paused">Pracovní aplikace jsou pozastavené</string>
+    <string name="you_won_t_receive_notifications_from_your_work_apps">Nebudete dostávat upozornění od pracovních aplikací</string>
+    <string name="unpause">Probudit</string>
+    <string name="private_space">Soukromý prostor</string>
+    <string name="please_wait_for_the_white_box_indicator">Počkejte prosím, až se objeví indikátor bílého rámečku</string>
+    <string name="edit_pages">Upravit stránky</string>
+    <string name="edit_dock_pages">Upravit stránky dokovací oblasti</string>
+    <string name="widgets">Widgety</string>
+    <string name="shortcuts">Zkratky</string>
+    <string name="wallpaper">Tapeta</string>
+    <string name="search_widgets">Hledat widgety</string>
+    <string name="request_permissions">Žádost o oprávnění</string>
+    <string name="allow_permissions_so_we_can_inform_you_about_important_crash_reports_and_make_phone_shortcuts">Povolit oprávnění, abychom vás mohli informovat o důležitých hlášeních o selháních a vytvářet zkratky telefonu</string>
+    <string name="later">Později</string>
+    <string name="alphabetical">Abecední</string>
+    <string name="index">Index</string>
+</resources>

--- a/feature/pin/src/main/res/values-cs/strings.xml
+++ b/feature/pin/src/main/res/values-cs/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="touch_and_hold_the_widget_to_move_it_around_the_home_screen">Dotknutím a podržením widgetu jej můžete přesouvat po domovské obrazovce</string>
+</resources>

--- a/feature/settings/app-drawer/src/main/res/values-cs/strings.xml
+++ b/feature/settings/app-drawer/src/main/res/values-cs/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="horizontal_grid">Horizontální mřížka</string>
+    <string name="vertical_grid">Vertikální mřížka</string>
+    <string name="rows_height">Výška řádků</string>
+    <string name="rows_height_is_not_valid">Výška řádků není platná</string>
+    <string name="hidden_applications">Skryté aplikace</string>
+    <string name="no_hidden_applications">Žádné skryté aplikace</string>
+    <string name="app_drawer_type">Typ nabídky aplikací</string>
+    <string name="exclude_tagged_apps">Vyřadit oštítkované aplikace</string>
+    <string name="hide_selected_apps_from_the_app_drawer">Skrýt vybrané aplikace z nabídky aplikací</string>
+    <string name="hide_apps_marked_with_selected_tags">Skrýt aplikace označené vybranými štítky</string>
+    <string name="show_keyboard">Zobrazit klávesnici</string>
+    <string name="show_keyboard_when_app_drawer_opens">Zobrazit klávesnici při otevření nabídky</string>
+    <string name="fuzzy_search">Fuzzy vyhledávání</string>
+    <string name="find_apps_even_with_typos_or_accented_characters">Vyhledávat aplikace i s překlepy nebo diakritikou</string>
+    <string name="blur_behind">Rozmazání pozadí</string>
+    <string name="blurs_the_wallpaper_when_app_drawer_opens">Rozmazat tapetu při otevření nabídky aplikací</string>
+</resources>

--- a/feature/settings/experimental/src/main/res/values-cs/strings.xml
+++ b/feature/settings/experimental/src/main/res/values-cs/strings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="warning">Varování</string>
+    <string name="disable_background_sync_description">
+    Zakázání synchronizace na pozadí pomáhá ušetřit trochu paměti a zjednodušuje práci, ale také to znamená, že Yagni spouštěč nebude automaticky aktualizovat vaše aplikace, widgety ani zkratky.\n\nV nabídce aplikací se mohou zobrazovat zastaralé ikony, chybějící widgety nebo zkratky, které již nefungují.
+</string>
+    <string name="sync_data">Synchronizovat data</string>
+    <string name="keep_data_up_to_date">Udržovat data aktuální</string>
+    <string name="enable_or_disable_sync_data">Povolit nebo zakázat synchronizaci dat</string>
+    <string name="lock_movement">Zamknout přesouvání</string>
+    <string name="prevent_other_grid_items_from_moving">Zabránit přesouvání ostatních položek mřížky</string>
+    <string name="grid_item_animation">Animace položky mřížky</string>
+    <string name="enable_or_disable_animations">Povolení nebo zakázání animace položky mřížky</string>
+</resources>

--- a/feature/settings/general/src/main/res/values-cs/strings.xml
+++ b/feature/settings/general/src/main/res/values-cs/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="import_icon_pack">Importovat balíček ikon</string>
+    <string name="no_icon_packs">Žádné balíčky ikon</string>
+    <string name="select_icon_pack">Vybrat balíček ikon</string>
+    <string name="please_import_an_icon_pack_first">Prosím, nejprve importujte balíček ikon</string>
+    <string name="reset">Resetovat</string>
+    <string name="default_icon_pack">Výchozí</string>
+    <string name="theme">Motiv</string>
+    <string name="dynamic_theme">Dynamický motiv</string>
+    <string name="notification_dots">Tečky oznámení</string>
+    <string name="show_notification_dots">Zobrazovat tečky oznámení</string>
+    <string name="apply_icons_from_supported_icon_packs">Použít ikony z podporovaných balíčků ikon</string>
+    <string name="adapt_colors_to_your_wallpaper_automatically">Automaticky přizpůsobit barvy tapetě</string>
+</resources>

--- a/feature/settings/home/src/main/res/values-cs/strings.xml
+++ b/feature/settings/home/src/main/res/values-cs/strings.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="dock_grid">Mřížka dokovací oblasti</string>
+    <string name="dock_columns_is_not_valid">Počet sloupců dokovací oblasti není platný</string>
+    <string name="dock_rows_is_not_valid">Počet řádků dokovací oblasti není platný</string>
+    <string name="dock_height">Výška dokovací oblasti</string>
+    <string name="dock_height_is_not_valid">Výška dokovací oblasti není platná</string>
+    <string name="folder_cell_dimension">Rozměr buňky složky</string>
+    <string name="cell_width">Šířka buňky</string>
+    <string name="cell_width_is_not_valid">Šířka buňky není platná</string>
+    <string name="cell_height">Výška buňky</string>
+    <string name="cell_height_is_not_valid">Výška buňky není platná</string>
+    <string name="max_columns">Maximum sloupců</string>
+    <string name="max_columns_is_not_valid">Maximální počet sloupců není platný</string>
+    <string name="folder_max_grid">Maximální rozměr mřížky složky</string>
+    <string name="max_rows">Maximum řádků</string>
+    <string name="max_rows_is_not_valid">Maximální počet řádků není platný</string>
+    <string name="infinite_scrolling">Nekonečné rolování</string>
+    <string name="seamless_loop_page_scroll">Bezešvá smyčka při rolování stránek</string>
+    <string name="wallpaper_scrolling">Rolování tapety</string>
+    <string name="scroll_wallpaper_across_pages">Rolování tapety napříč stránkami</string>
+    <string name="lock_screen_orientation">Zamknout otáčení obrazovky</string>
+    <string name="add_new_apps">Přidat nové aplikace</string>
+    <string name="add_new_apps_to_home_screen">Přidat nové aplikace na domovskou obrazovku</string>
+    <string name="dock">Dokovací oblast</string>
+    <string name="dock_infinite_scroll">Nekonečné rolování dokovací oblasti</string>
+    <string name="folder">Složka</string>
+    <string name="prevent_rotation_when_device_orientation_changes">Zabránit otáčení při změně natočení zařízení</string>
+    <string name="show_page_indicator">Zobrazit indikátor stránky</string>
+    <string name="show_an_indicator_for_the_current_page">Zobrazit indikátor pro aktuální stránku</string>
+    <string name="dock_background_color">Barva pozadí dokovací oblasti</string>
+    <string name="dock_padding">Odsazení dokovací oblasti</string>
+    <string name="dock_corner_radius">Zaoblení rohů dokovací oblasti</string>
+    <string name="dock_padding_is_not_valid">Odsazení dokovací oblasti není platné</string>
+    <string name="top_start">Levý horní</string>
+    <string name="top_start_is_not_valid">Levý horní není platný</string>
+    <string name="top_end">Pravý horní</string>
+    <string name="top_end_is_not_valid">Pravý horní není platný</string>
+    <string name="bottom_start">Levý dolní</string>
+    <string name="bottom_start_is_not_valid">Levý dolní není platný</string>
+    <string name="bottom_end">Pravý dolní</string>
+    <string name="bottom_end_is_not_valid">Pravý dolní není platný</string>
+    <string name="set_the_radius_for_each_dock_corner">Nastavit zaoblení každého rohu dokovací oblasti</string>
+    <string name="folder_corner_radius">Zaoblení rohů složky</string>
+    <string name="folder_background_color">Barva pozadí složky</string>
+</resources>

--- a/feature/settings/settings/src/main/res/values-cs/strings.xml
+++ b/feature/settings/settings/src/main/res/values-cs/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="choose_yagni_launcher">Vybrat Yagni spouštěč</string>
+    <string name="default_launcher">Výchozí spouštěč</string>
+    <string name="themes_icon_packs">Motivy, balíčky ikon</string>
+    <string name="grid_icon_dock_and_more">Mřížka, ikony, dokovací oblast a další</string>
+    <string name="columns_and_rows_count">Počty sloupců a řádků</string>
+    <string name="swipe_gesture_actions">Akce pro gesta přejetí prstem</string>
+    <string name="advanced_options_for_power_users">Pokročilé možnosti pro náročné uživatele</string>
+    <string name="thank_you_for_using_yagni_launcher_alpha">Děkujeme, že používáte Yagni spouštěč v alfa verzi!</string>
+    <string name="about_development_description">
+    Vývoj začal v lednu 2025 s pravidelnými týdenními aktualizacemi. Toto je můj dosud nejsložitější projekt a věnuji značné úsilí jeho vylepšování.
+</string>
+    <string name="support_message">
+    Pokud shledáte aplikaci hodnotnou, velmi uvítáme vaši podporu, ať už darem na Ko-Fi nebo udělením hvězdičky repozitáři na GitHubu.
+</string>
+    <string name="support_on_ko_fi">Podpořit na Ko-Fi</string>
+    <string name="star_on_github">Hvězdička na GitHubu</string>
+    <string name="note_this_informational_card_will_be_removed_in_future_stable_releases">Poznámka: Tato informační karta bude odstraněna v budoucích stabilních vydáních</string>
+</resources>

--- a/service/src/main/res/values-cs/strings.xml
+++ b/service/src/main/res/values-cs/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="accessibility_service_label">Yagni spouštěč</string>
+    <string name="accessibility_service_description">Akce gest pro Yagni spouštěč</string>
+    <string name="notification_listener_service">Služba naslouchání oznámením Yagni</string>
+    <string name="importing_into_cache">Importování %1$s do keše</string>
+    <string name="loading_icons_from_cache_is_faster">Načítání ikon z keše je rychlejší</string>
+</resources>

--- a/ui/src/main/res/values-cs/strings.xml
+++ b/ui/src/main/res/values-cs/strings.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~   Copyright 2023 Einstein Blanco
+  ~
+  ~   Licensed under the GNU General Public License v3.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~       https://www.gnu.org/licenses/gpl-3.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~
+  -->
+<resources>
+    <string name="open">Otevřít %1$s</string>
+    <string name="app">Aplikace</string>
+    <string name="open_app_drawer">Otevřít nabídku aplikací</string>
+    <string name="open_notification_panel">Otevřít panel oznámení</string>
+    <string name="lock_screen">Zamknout obrazovku</string>
+    <string name="open_quick_settings">Otevřít rychlá nastavení</string>
+    <string name="open_recents">Otevřít nedávné</string>
+    <string name="enable_the_accessibility_service_permission_to_use_additional_actions">Povolit oprávnění ke službě přístupnosti pro používání dalších akcí</string>
+    <string name="corner_radius">Zaoblení rohů</string>
+    <string name="corner_radius_is_not_valid">Zaoblení rohů není platné</string>
+    <string name="icon_size">Velikost ikon</string>
+    <string name="icon_size_is_not_valid">Velikost ikon není platná</string>
+    <string name="padding">Odsazení</string>
+    <string name="padding_is_not_valid">Odsazení není platné</string>
+    <string name="text_size">Velikost textu</string>
+    <string name="text_size_is_not_valid">Velikost textu není platná</string>
+    <string name="select_application">Vybrat aplikaci</string>
+    <string name="custom_icon">Vlastní ikona</string>
+    <string name="gallery">Galerie</string>
+    <string name="pick_icons_from_your_gallery">Vyberte ikony z vaší galerie</string>
+    <string name="reset_custom_icon">Resetovat vlastní ikonu</string>
+    <string name="grid_item">Položka mřížky</string>
+    <string name="text_color">Barva textu</string>
+    <string name="show_label">Zobrazovat název</string>
+    <string name="single_line_label">Jednořádkový název</string>
+    <string name="horizontal_alignment">Horizontální zarovnání</string>
+    <string name="vertical_arrangement">Vertikální zarovnání</string>
+    <string name="start">Vlevo</string>
+    <string name="center_horizontally">Uprostřed</string>
+    <string name="end">Vpravo</string>
+    <string name="bottom">Dole</string>
+    <string name="top">Nahoře</string>
+    <string name="center">Uprostřed</string>
+    <string name="double_tap">Poklepání</string>
+    <string name="swipe_up">Přejetí prstem nahoru</string>
+    <string name="swipe_down">Přejetí prstem dolů</string>
+    <string name="display_app_names_below_icons">Zobrazovat názvy aplikací pod ikonami</string>
+    <string name="limit_app_names_to_one_line">Omezit názvy aplikací na jeden řádek</string>
+    <string name="custom">Vlastní</string>
+</resources>


### PR DESCRIPTION
I really liked Yagni launcher and would like to help with the translation, in this case into Czech. I tried to make the translation complete to the current state of the git tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive Czech localization across the launcher, settings, home screen, app drawer, widgets, services, and editing features.
  - Czech translations now cover navigation, configuration options, accessibility labels, actions, themes, icons, gestures, appearance settings, and validation messages.
  - Added Czech app names and launcher action labels for standard and debug builds, plus localized guidance for widget and service interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->