### PR TITLE
Cleanup State

### DIFF
--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/FolderGrid.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/FolderGrid.kt
@@ -17,7 +17,10 @@
  */
 package com.eblan.launcher.feature.home.component
 
+import androidx.compose.animation.core.VisibilityThreshold
 import androidx.compose.animation.core.animateIntAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
@@ -156,20 +159,25 @@ private fun FolderGridLayoutContent(
     val x = (index % columns) * cellWidth
     val y = (index / columns) * cellHeight
 
+    val animationSpec =
+        if (animate) spring(visibilityThreshold = Int.VisibilityThreshold) else snap()
+
     val animatedX by animateIntAsState(
         targetValue = x,
         label = "x",
+        animationSpec = animationSpec,
     )
 
     val animatedY by animateIntAsState(
         targetValue = y,
         label = "y",
+        animationSpec = animationSpec,
     )
 
     Box(
         modifier = modifier.folderGridItem(
-            x = if (animate) animatedX else x,
-            y = if (animate) animatedY else y,
+            x = animatedX,
+            y = animatedY,
             width = cellWidth,
             height = cellHeight,
         ),

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/FolderGrid.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/FolderGrid.kt
@@ -17,14 +17,9 @@
  */
 package com.eblan.launcher.feature.home.component
 
-import androidx.compose.animation.core.VisibilityThreshold
-import androidx.compose.animation.core.animateIntAsState
-import androidx.compose.animation.core.snap
-import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ParentDataModifier
 import androidx.compose.ui.layout.SubcomposeLayout
@@ -159,20 +154,8 @@ private fun FolderGridLayoutContent(
     val x = (index % columns) * cellWidth
     val y = (index / columns) * cellHeight
 
-    val animationSpec =
-        if (animate) spring(visibilityThreshold = Int.VisibilityThreshold) else snap()
-
-    val animatedX by animateIntAsState(
-        targetValue = x,
-        label = "x",
-        animationSpec = animationSpec,
-    )
-
-    val animatedY by animateIntAsState(
-        targetValue = y,
-        label = "y",
-        animationSpec = animationSpec,
-    )
+    val animatedX = animateGridIntAsState(targetValue = x, animate = animate)
+    val animatedY = animateGridIntAsState(targetValue = y, animate = animate)
 
     Box(
         modifier = modifier.folderGridItem(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Grid.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Grid.kt
@@ -17,14 +17,15 @@
  */
 package com.eblan.launcher.feature.home.component
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.VisibilityThreshold
-import androidx.compose.animation.core.animateIntAsState
-import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ParentDataModifier
 import androidx.compose.ui.layout.SubcomposeLayout
@@ -125,6 +126,35 @@ internal fun HorizontalAppDrawerGridLayout(
 }
 
 @Composable
+internal fun animateGridIntAsState(
+    targetValue: Int,
+    animate: Boolean,
+): Int {
+    val animatable = remember {
+        Animatable(
+            initialValue = targetValue,
+            typeConverter = Int.VectorConverter,
+        )
+    }
+
+    LaunchedEffect(
+        key1 = targetValue,
+        key2 = animate,
+    ) {
+        if (animate) {
+            animatable.animateTo(
+                targetValue = targetValue,
+                animationSpec = spring(visibilityThreshold = Int.VisibilityThreshold),
+            )
+        } else {
+            animatable.snapTo(targetValue)
+        }
+    }
+
+    return animatable.value
+}
+
+@Composable
 private fun GridLayoutItem(
     modifier: Modifier = Modifier,
     gridItem: GridItem,
@@ -139,32 +169,10 @@ private fun GridLayoutItem(
     val x = gridItem.startColumn * cellWidth
     val y = gridItem.startRow * cellHeight
 
-    val animationSpec =
-        if (animate) spring(visibilityThreshold = Int.VisibilityThreshold) else snap()
-
-    val animatedWidth by animateIntAsState(
-        targetValue = width,
-        label = "width",
-        animationSpec = animationSpec,
-    )
-
-    val animatedHeight by animateIntAsState(
-        targetValue = height,
-        label = "height",
-        animationSpec = animationSpec,
-    )
-
-    val animatedX by animateIntAsState(
-        targetValue = x,
-        label = "x",
-        animationSpec = animationSpec,
-    )
-
-    val animatedY by animateIntAsState(
-        targetValue = y,
-        label = "y",
-        animationSpec = animationSpec,
-    )
+    val animatedWidth = animateGridIntAsState(targetValue = width, animate = animate)
+    val animatedHeight = animateGridIntAsState(targetValue = height, animate = animate)
+    val animatedX = animateGridIntAsState(targetValue = x, animate = animate)
+    val animatedY = animateGridIntAsState(targetValue = y, animate = animate)
 
     Box(
         modifier = modifier.gridItem(

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Grid.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Grid.kt
@@ -151,7 +151,7 @@ internal fun animateGridIntAsState(
         }
     }
 
-    return animatable.value
+    return if (animate) animatable.value else targetValue
 }
 
 @Composable

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Grid.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Grid.kt
@@ -151,7 +151,7 @@ internal fun animateGridIntAsState(
         }
     }
 
-    return if (animate) animatable.value else targetValue
+    return animatable.value
 }
 
 @Composable

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Grid.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/component/Grid.kt
@@ -17,7 +17,10 @@
  */
 package com.eblan.launcher.feature.home.component
 
+import androidx.compose.animation.core.VisibilityThreshold
 import androidx.compose.animation.core.animateIntAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
@@ -136,32 +139,39 @@ private fun GridLayoutItem(
     val x = gridItem.startColumn * cellWidth
     val y = gridItem.startRow * cellHeight
 
+    val animationSpec =
+        if (animate) spring(visibilityThreshold = Int.VisibilityThreshold) else snap()
+
     val animatedWidth by animateIntAsState(
         targetValue = width,
         label = "width",
+        animationSpec = animationSpec,
     )
 
     val animatedHeight by animateIntAsState(
         targetValue = height,
         label = "height",
+        animationSpec = animationSpec,
     )
 
     val animatedX by animateIntAsState(
         targetValue = x,
         label = "x",
+        animationSpec = animationSpec,
     )
 
     val animatedY by animateIntAsState(
         targetValue = y,
         label = "y",
+        animationSpec = animationSpec,
     )
 
     Box(
         modifier = modifier.gridItem(
-            width = if (animate) animatedWidth else width,
-            height = if (animate) animatedHeight else height,
-            x = if (animate) animatedX else x,
-            y = if (animate) animatedY else y,
+            width = animatedWidth,
+            height = animatedHeight,
+            x = animatedX,
+            y = animatedY,
         ),
         content = {
             content(gridItem)

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/folder/FolderScreen.kt
@@ -441,7 +441,7 @@ internal fun FolderScreen(
                         rows = folderPopup.rows,
                         width = animatedPreviewRect.width().roundToInt(),
                         height = animatedPreviewRect.height().roundToInt(),
-                        animate = isVisibleOverlay && animations,
+                        animate = isVisibleOverlay && !isInProgress && animations,
                         content = {
                             InteractiveFolderGridItem(
                                 sharedTransitionScope = sharedTransitionScope,

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/GridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/GridItemResizeOverlay.kt
@@ -223,13 +223,13 @@ internal fun GridItemResizeOverlay(
                         },
                         onDrag = { _, dragAmount ->
                             scope.launch {
-                                currentWidth.snapTo(currentWidth.value - dragAmount.x.roundToInt())
+                                currentWidth.snapTo((currentWidth.value - dragAmount.x).roundToInt())
 
-                                currentHeight.snapTo(currentHeight.value - dragAmount.y.roundToInt())
+                                currentHeight.snapTo((currentHeight.value - dragAmount.y).roundToInt())
 
-                                currentX.snapTo(currentX.value + dragAmount.x.roundToInt())
+                                currentX.snapTo((currentX.value + dragAmount.x).roundToInt())
 
-                                currentY.snapTo(currentY.value + dragAmount.y.roundToInt())
+                                currentY.snapTo((currentY.value + dragAmount.y).roundToInt())
                             }
                         },
                     )
@@ -253,11 +253,11 @@ internal fun GridItemResizeOverlay(
                         },
                         onDrag = { _, dragAmount ->
                             scope.launch {
-                                currentWidth.snapTo(currentWidth.value + dragAmount.x.roundToInt())
+                                currentWidth.snapTo((currentWidth.value + dragAmount.x).roundToInt())
 
-                                currentHeight.snapTo(currentHeight.value - dragAmount.y.roundToInt())
+                                currentHeight.snapTo((currentHeight.value - dragAmount.y).roundToInt())
 
-                                currentY.snapTo(currentY.value + dragAmount.y.roundToInt())
+                                currentY.snapTo((currentY.value + dragAmount.y).roundToInt())
                             }
                         },
                     )
@@ -281,11 +281,11 @@ internal fun GridItemResizeOverlay(
                         },
                         onDrag = { _, dragAmount ->
                             scope.launch {
-                                currentWidth.snapTo(currentWidth.value - dragAmount.x.roundToInt())
+                                currentWidth.snapTo((currentWidth.value - dragAmount.x).roundToInt())
 
-                                currentHeight.snapTo(currentHeight.value + dragAmount.y.roundToInt())
+                                currentHeight.snapTo((currentHeight.value + dragAmount.y).roundToInt())
 
-                                currentX.snapTo(currentX.value + dragAmount.x.roundToInt())
+                                currentX.snapTo((currentX.value + dragAmount.x).roundToInt())
                             }
                         },
                     )
@@ -309,9 +309,9 @@ internal fun GridItemResizeOverlay(
                         },
                         onDrag = { _, dragAmount ->
                             scope.launch {
-                                currentWidth.snapTo(currentWidth.value + dragAmount.x.roundToInt())
+                                currentWidth.snapTo((currentWidth.value + dragAmount.x).roundToInt())
 
-                                currentHeight.snapTo(currentHeight.value + dragAmount.y.roundToInt())
+                                currentHeight.snapTo((currentHeight.value + dragAmount.y).roundToInt())
                             }
                         },
                     )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/GridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/GridItemResizeOverlay.kt
@@ -18,7 +18,7 @@
 package com.eblan.launcher.feature.home.screen.resize
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.VectorConverter
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -75,13 +75,33 @@ internal fun GridItemResizeOverlay(
 
     val scope = rememberCoroutineScope()
 
-    val currentX = remember { Animatable(x.toFloat()) }
+    val currentX = remember {
+        Animatable(
+            initialValue = x,
+            typeConverter = Int.VectorConverter,
+        )
+    }
 
-    val currentY = remember { Animatable(y.toFloat()) }
+    val currentY = remember {
+        Animatable(
+            initialValue = y,
+            typeConverter = Int.VectorConverter,
+        )
+    }
 
-    val currentWidth = remember { Animatable(width.toFloat()) }
+    val currentWidth = remember {
+        Animatable(
+            initialValue = width,
+            typeConverter = Int.VectorConverter,
+        )
+    }
 
-    val currentHeight = remember { Animatable(height.toFloat()) }
+    val currentHeight = remember {
+        Animatable(
+            initialValue = height,
+            typeConverter = Int.VectorConverter,
+        )
+    }
 
     var isResizing by remember {
         mutableStateOf(true)
@@ -96,7 +116,7 @@ internal fun GridItemResizeOverlay(
     val borderWidth by remember {
         derivedStateOf {
             with(density) {
-                currentWidth.value.roundToInt().coerceAtLeast(dragHandleSizePx).toDp()
+                currentWidth.value.coerceAtLeast(dragHandleSizePx).toDp()
             }
         }
     }
@@ -104,7 +124,7 @@ internal fun GridItemResizeOverlay(
     val borderHeight by remember {
         derivedStateOf {
             with(density) {
-                currentHeight.value.roundToInt().coerceAtLeast(dragHandleSizePx).toDp()
+                currentHeight.value.coerceAtLeast(dragHandleSizePx).toDp()
             }
         }
     }
@@ -113,9 +133,9 @@ internal fun GridItemResizeOverlay(
         derivedStateOf {
             getBorderX(
                 dragHandle = dragHandle,
-                currentWidth = currentWidth,
+                currentWidth = currentWidth.value,
                 dragHandleSizePx = dragHandleSizePx,
-                currentX = currentX,
+                currentX = currentX.value,
                 x = x,
                 width = width,
             )
@@ -126,9 +146,9 @@ internal fun GridItemResizeOverlay(
         derivedStateOf {
             getBorderY(
                 dragHandle = dragHandle,
-                currentHeight = currentHeight,
+                currentHeight = currentHeight.value,
                 dragHandleSizePx = dragHandleSizePx,
-                currentY = currentY,
+                currentY = currentY.value,
                 y = y,
                 height = height,
             )
@@ -144,9 +164,9 @@ internal fun GridItemResizeOverlay(
         key2 = currentHeight.value,
     ) {
         resizeGridItem(
-            currentWidth = currentWidth,
+            currentWidth = currentWidth.value,
             cellWidth = cellWidth,
-            currentHeight = currentHeight,
+            currentHeight = currentHeight.value,
             cellHeight = cellHeight,
             dragHandle = dragHandle,
             gridItem = gridItem,
@@ -162,13 +182,13 @@ internal fun GridItemResizeOverlay(
 
     LaunchedEffect(key1 = isResizing) {
         if (!isResizing) {
-            launch { currentX.animateTo(x.toFloat()) }
+            launch { currentX.animateTo(targetValue = x) }
 
-            launch { currentY.animateTo(y.toFloat()) }
+            launch { currentY.animateTo(targetValue = y) }
 
-            launch { currentWidth.animateTo(width.toFloat()) }
+            launch { currentWidth.animateTo(targetValue = width) }
 
-            launch { currentHeight.animateTo(height.toFloat()) }
+            launch { currentHeight.animateTo(targetValue = height) }
         }
     }
 
@@ -203,13 +223,13 @@ internal fun GridItemResizeOverlay(
                         },
                         onDrag = { _, dragAmount ->
                             scope.launch {
-                                currentWidth.snapTo(currentWidth.value - dragAmount.x)
+                                currentWidth.snapTo(currentWidth.value - dragAmount.x.roundToInt())
 
-                                currentHeight.snapTo(currentHeight.value - dragAmount.y)
+                                currentHeight.snapTo(currentHeight.value - dragAmount.y.roundToInt())
 
-                                currentX.snapTo(currentX.value + dragAmount.x)
+                                currentX.snapTo(currentX.value + dragAmount.x.roundToInt())
 
-                                currentY.snapTo(currentY.value + dragAmount.y)
+                                currentY.snapTo(currentY.value + dragAmount.y.roundToInt())
                             }
                         },
                     )
@@ -233,11 +253,11 @@ internal fun GridItemResizeOverlay(
                         },
                         onDrag = { _, dragAmount ->
                             scope.launch {
-                                currentWidth.snapTo(currentWidth.value + dragAmount.x)
+                                currentWidth.snapTo(currentWidth.value + dragAmount.x.roundToInt())
 
-                                currentHeight.snapTo(currentHeight.value - dragAmount.y)
+                                currentHeight.snapTo(currentHeight.value - dragAmount.y.roundToInt())
 
-                                currentY.snapTo(currentY.value + dragAmount.y)
+                                currentY.snapTo(currentY.value + dragAmount.y.roundToInt())
                             }
                         },
                     )
@@ -261,11 +281,11 @@ internal fun GridItemResizeOverlay(
                         },
                         onDrag = { _, dragAmount ->
                             scope.launch {
-                                currentWidth.snapTo(currentWidth.value - dragAmount.x)
+                                currentWidth.snapTo(currentWidth.value - dragAmount.x.roundToInt())
 
-                                currentHeight.snapTo(currentHeight.value + dragAmount.y)
+                                currentHeight.snapTo(currentHeight.value + dragAmount.y.roundToInt())
 
-                                currentX.snapTo(currentX.value + dragAmount.x)
+                                currentX.snapTo(currentX.value + dragAmount.x.roundToInt())
                             }
                         },
                     )
@@ -289,9 +309,9 @@ internal fun GridItemResizeOverlay(
                         },
                         onDrag = { _, dragAmount ->
                             scope.launch {
-                                currentWidth.snapTo(currentWidth.value + dragAmount.x)
+                                currentWidth.snapTo(currentWidth.value + dragAmount.x.roundToInt())
 
-                                currentHeight.snapTo(currentHeight.value + dragAmount.y)
+                                currentHeight.snapTo(currentHeight.value + dragAmount.y.roundToInt())
                             }
                         },
                     )
@@ -302,13 +322,13 @@ internal fun GridItemResizeOverlay(
 
 private fun getBorderY(
     dragHandle: Alignment,
-    currentHeight: Animatable<Float, AnimationVector1D>,
+    currentHeight: Int,
     dragHandleSizePx: Int,
-    currentY: Animatable<Float, AnimationVector1D>,
+    currentY: Int,
     y: Int,
     height: Int,
-): Int = if (currentHeight.value >= dragHandleSizePx) {
-    currentY.value.roundToInt()
+): Int = if (currentHeight >= dragHandleSizePx) {
+    currentY
 } else if (dragHandle == Alignment.TopStart || dragHandle == Alignment.TopEnd) {
     (y + height) - dragHandleSizePx
 } else {
@@ -317,39 +337,39 @@ private fun getBorderY(
 
 private fun getBorderX(
     dragHandle: Alignment,
-    currentWidth: Animatable<Float, AnimationVector1D>,
+    currentWidth: Int,
     dragHandleSizePx: Int,
-    currentX: Animatable<Float, AnimationVector1D>,
+    currentX: Int,
     x: Int,
     width: Int,
 ): Int = when (dragHandle) {
     Alignment.TopStart -> {
-        if (currentWidth.value >= dragHandleSizePx) {
-            currentX.value.roundToInt()
+        if (currentWidth >= dragHandleSizePx) {
+            currentX
         } else {
             (x + width) - dragHandleSizePx
         }
     }
 
     Alignment.TopEnd -> {
-        if (currentWidth.value >= dragHandleSizePx) {
-            currentX.value.roundToInt()
+        if (currentWidth >= dragHandleSizePx) {
+            currentX
         } else {
             x
         }
     }
 
     Alignment.BottomStart -> {
-        if (currentWidth.value >= dragHandleSizePx) {
-            currentX.value.roundToInt()
+        if (currentWidth >= dragHandleSizePx) {
+            currentX
         } else {
             (x + width) - dragHandleSizePx
         }
     }
 
     else -> {
-        if (currentWidth.value >= dragHandleSizePx) {
-            currentX.value.roundToInt()
+        if (currentWidth >= dragHandleSizePx) {
+            currentX
         } else {
             x
         }
@@ -357,9 +377,9 @@ private fun getBorderX(
 }
 
 private fun resizeGridItem(
-    currentWidth: Animatable<Float, AnimationVector1D>,
+    currentWidth: Int,
     cellWidth: Int,
-    currentHeight: Animatable<Float, AnimationVector1D>,
+    currentHeight: Int,
     cellHeight: Int,
     dragHandle: Alignment,
     gridItem: GridItem,
@@ -371,9 +391,9 @@ private fun resizeGridItem(
     lockMovement: Boolean,
     onResizeGridItem: (GridItem, Int, Int) -> Unit,
 ) {
-    val allowedWidth = currentWidth.value.roundToInt().coerceAtLeast(cellWidth)
+    val allowedWidth = currentWidth.coerceAtLeast(cellWidth)
 
-    val allowedHeight = currentHeight.value.roundToInt().coerceAtLeast(cellHeight)
+    val allowedHeight = currentHeight.coerceAtLeast(cellHeight)
 
     val resizingGridItem = when (dragHandle) {
         Alignment.TopStart -> {

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/WidgetGridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/WidgetGridItemResizeOverlay.kt
@@ -230,8 +230,8 @@ internal fun WidgetGridItemResizeOverlay(
                                 },
                                 onDrag = { _, dragAmount ->
                                     scope.launch {
-                                        currentHeight.snapTo(currentHeight.value - dragAmount.y.roundToInt())
-                                        currentY.snapTo(currentY.value + dragAmount.y.roundToInt())
+                                        currentHeight.snapTo((currentHeight.value - dragAmount.y).roundToInt())
+                                        currentY.snapTo((currentY.value + dragAmount.y).roundToInt())
                                     }
                                 },
                             )
@@ -260,7 +260,7 @@ internal fun WidgetGridItemResizeOverlay(
                                 },
                                 onDrag = { _, dragAmount ->
                                     scope.launch {
-                                        currentWidth.snapTo(currentWidth.value + dragAmount.x.roundToInt())
+                                        currentWidth.snapTo((currentWidth.value + dragAmount.x).roundToInt())
                                     }
                                 },
                             )
@@ -289,7 +289,7 @@ internal fun WidgetGridItemResizeOverlay(
                                 },
                                 onDrag = { _, dragAmount ->
                                     scope.launch {
-                                        currentHeight.snapTo(currentHeight.value + dragAmount.y.roundToInt())
+                                        currentHeight.snapTo((currentHeight.value + dragAmount.y).roundToInt())
                                     }
                                 },
                             )
@@ -318,8 +318,8 @@ internal fun WidgetGridItemResizeOverlay(
                                 },
                                 onDrag = { _, dragAmount ->
                                     scope.launch {
-                                        currentWidth.snapTo(currentWidth.value - dragAmount.x.roundToInt())
-                                        currentX.snapTo(currentX.value + dragAmount.x.roundToInt())
+                                        currentWidth.snapTo((currentWidth.value - dragAmount.x).roundToInt())
+                                        currentX.snapTo((currentX.value + dragAmount.x).roundToInt())
                                     }
                                 },
                             )

--- a/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/WidgetGridItemResizeOverlay.kt
+++ b/feature/home/src/main/kotlin/com/eblan/launcher/feature/home/screen/resize/WidgetGridItemResizeOverlay.kt
@@ -19,7 +19,7 @@ package com.eblan.launcher.feature.home.screen.resize
 
 import android.appwidget.AppWidgetProviderInfo
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.VectorConverter
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -53,6 +53,7 @@ import com.eblan.launcher.feature.home.util.updateAppWidgetOptions
 import com.eblan.launcher.framework.widgetmanager.AndroidAppWidgetManagerWrapper
 import com.eblan.launcher.ui.local.LocalAppWidgetManager
 import kotlinx.coroutines.launch
+import kotlin.Int
 import kotlin.math.roundToInt
 
 @Composable
@@ -82,13 +83,33 @@ internal fun WidgetGridItemResizeOverlay(
 
     val appWidgetManager = LocalAppWidgetManager.current
 
-    val currentX = remember { Animatable(x.toFloat()) }
+    val currentX = remember {
+        Animatable(
+            initialValue = x,
+            typeConverter = Int.VectorConverter,
+        )
+    }
 
-    val currentY = remember { Animatable(y.toFloat()) }
+    val currentY = remember {
+        Animatable(
+            initialValue = y,
+            typeConverter = Int.VectorConverter,
+        )
+    }
 
-    val currentWidth = remember { Animatable(width.toFloat()) }
+    val currentWidth = remember {
+        Animatable(
+            initialValue = width,
+            typeConverter = Int.VectorConverter,
+        )
+    }
 
-    val currentHeight = remember { Animatable(height.toFloat()) }
+    val currentHeight = remember {
+        Animatable(
+            initialValue = height,
+            typeConverter = Int.VectorConverter,
+        )
+    }
 
     var isResizing by remember {
         mutableStateOf(true)
@@ -103,7 +124,7 @@ internal fun WidgetGridItemResizeOverlay(
     val borderWidth by remember {
         derivedStateOf {
             with(density) {
-                currentWidth.value.roundToInt().coerceAtLeast(dragHandleSizePx).toDp()
+                currentWidth.value.coerceAtLeast(dragHandleSizePx).toDp()
             }
         }
     }
@@ -111,18 +132,18 @@ internal fun WidgetGridItemResizeOverlay(
     val borderHeight by remember {
         derivedStateOf {
             with(density) {
-                currentHeight.value.roundToInt().coerceAtLeast(dragHandleSizePx).toDp()
+                currentHeight.value.coerceAtLeast(dragHandleSizePx).toDp()
             }
         }
     }
 
     val borderX by remember {
         derivedStateOf {
-            getBorderX(
+            getWidgetBorderX(
                 dragHandle = dragHandle,
-                currentWidth = currentWidth,
+                currentWidth = currentWidth.value,
                 dragHandleSizePx = dragHandleSizePx,
-                currentX = currentX,
+                currentX = currentX.value,
                 x = x,
                 width = width,
             )
@@ -131,11 +152,11 @@ internal fun WidgetGridItemResizeOverlay(
 
     val borderY by remember {
         derivedStateOf {
-            getBorderY(
+            getWidgetBorderY(
                 dragHandle = dragHandle,
-                currentHeight = currentHeight,
+                currentHeight = currentHeight.value,
                 dragHandleSizePx = dragHandleSizePx,
-                currentY = currentY,
+                currentY = currentY.value,
                 y = y,
                 height = height,
             )
@@ -151,10 +172,10 @@ internal fun WidgetGridItemResizeOverlay(
         key1 = currentWidth.value,
         key2 = currentHeight.value,
     ) {
-        resizeGridItem(
+        resizeWidgetGridItem(
             data = data,
-            currentWidth = currentWidth,
-            currentHeight = currentHeight,
+            currentWidth = currentWidth.value,
+            currentHeight = currentHeight.value,
             dragHandle = dragHandle,
             gridItem = gridItem,
             width = width,
@@ -173,10 +194,10 @@ internal fun WidgetGridItemResizeOverlay(
 
     LaunchedEffect(key1 = isResizing) {
         if (!isResizing) {
-            launch { currentX.animateTo(x.toFloat()) }
-            launch { currentY.animateTo(y.toFloat()) }
-            launch { currentWidth.animateTo(width.toFloat()) }
-            launch { currentHeight.animateTo(height.toFloat()) }
+            launch { currentX.animateTo(targetValue = x) }
+            launch { currentY.animateTo(targetValue = y) }
+            launch { currentWidth.animateTo(targetValue = width) }
+            launch { currentHeight.animateTo(targetValue = height) }
         }
     }
 
@@ -209,8 +230,8 @@ internal fun WidgetGridItemResizeOverlay(
                                 },
                                 onDrag = { _, dragAmount ->
                                     scope.launch {
-                                        currentHeight.snapTo(currentHeight.value - dragAmount.y)
-                                        currentY.snapTo(currentY.value + dragAmount.y)
+                                        currentHeight.snapTo(currentHeight.value - dragAmount.y.roundToInt())
+                                        currentY.snapTo(currentY.value + dragAmount.y.roundToInt())
                                     }
                                 },
                             )
@@ -239,7 +260,7 @@ internal fun WidgetGridItemResizeOverlay(
                                 },
                                 onDrag = { _, dragAmount ->
                                     scope.launch {
-                                        currentWidth.snapTo(currentWidth.value + dragAmount.x)
+                                        currentWidth.snapTo(currentWidth.value + dragAmount.x.roundToInt())
                                     }
                                 },
                             )
@@ -268,7 +289,7 @@ internal fun WidgetGridItemResizeOverlay(
                                 },
                                 onDrag = { _, dragAmount ->
                                     scope.launch {
-                                        currentHeight.snapTo(currentHeight.value + dragAmount.y)
+                                        currentHeight.snapTo(currentHeight.value + dragAmount.y.roundToInt())
                                     }
                                 },
                             )
@@ -297,8 +318,8 @@ internal fun WidgetGridItemResizeOverlay(
                                 },
                                 onDrag = { _, dragAmount ->
                                     scope.launch {
-                                        currentWidth.snapTo(currentWidth.value - dragAmount.x)
-                                        currentX.snapTo(currentX.value + dragAmount.x)
+                                        currentWidth.snapTo(currentWidth.value - dragAmount.x.roundToInt())
+                                        currentX.snapTo(currentX.value + dragAmount.x.roundToInt())
                                     }
                                 },
                             )
@@ -311,44 +332,44 @@ internal fun WidgetGridItemResizeOverlay(
     }
 }
 
-private fun getBorderX(
+private fun getWidgetBorderX(
     dragHandle: Alignment,
-    currentWidth: Animatable<Float, AnimationVector1D>,
+    currentWidth: Int,
     dragHandleSizePx: Int,
-    currentX: Animatable<Float, AnimationVector1D>,
+    currentX: Int,
     x: Int,
     width: Int,
 ): Int = if (dragHandle == Alignment.CenterStart) {
-    if (currentWidth.value >= dragHandleSizePx) {
-        currentX.value.roundToInt()
+    if (currentWidth >= dragHandleSizePx) {
+        currentX
     } else {
         (x + width) - dragHandleSizePx
     }
 } else {
-    currentX.value.roundToInt()
+    currentX
 }
 
-private fun getBorderY(
+private fun getWidgetBorderY(
     dragHandle: Alignment,
-    currentHeight: Animatable<Float, AnimationVector1D>,
+    currentHeight: Int,
     dragHandleSizePx: Int,
-    currentY: Animatable<Float, AnimationVector1D>,
+    currentY: Int,
     y: Int,
     height: Int,
 ): Int = if (dragHandle == Alignment.TopCenter) {
-    if (currentHeight.value >= dragHandleSizePx) {
-        currentY.value.roundToInt()
+    if (currentHeight >= dragHandleSizePx) {
+        currentY
     } else {
         (y + height) - dragHandleSizePx
     }
 } else {
-    currentY.value.roundToInt()
+    currentY
 }
 
-private fun resizeGridItem(
+private fun resizeWidgetGridItem(
     data: GridItemData.Widget,
-    currentWidth: Animatable<Float, AnimationVector1D>,
-    currentHeight: Animatable<Float, AnimationVector1D>,
+    currentWidth: Int,
+    currentHeight: Int,
     dragHandle: Alignment,
     gridItem: GridItem,
     width: Int,
@@ -364,21 +385,21 @@ private fun resizeGridItem(
     onResizeWidgetGridItem: (GridItem, Int, Int) -> Unit,
 ) {
     val allowedWidth =
-        if (data.minResizeWidth > 0 && currentWidth.value.roundToInt() <= data.minResizeWidth) {
+        if (data.minResizeWidth > 0 && currentWidth <= data.minResizeWidth) {
             data.minResizeWidth
-        } else if (data.maxResizeWidth in 1..<currentWidth.value.roundToInt()) {
+        } else if (data.maxResizeWidth in 1..<currentWidth) {
             data.maxResizeWidth
         } else {
-            currentWidth.value.roundToInt()
+            currentWidth
         }
 
     val allowedHeight =
-        if (data.minResizeHeight > 0 && currentHeight.value.roundToInt() <= data.minResizeHeight) {
+        if (data.minResizeHeight > 0 && currentHeight <= data.minResizeHeight) {
             data.minResizeHeight
-        } else if (data.maxResizeHeight in 1..<currentHeight.value.roundToInt()) {
+        } else if (data.maxResizeHeight in 1..<currentHeight) {
             data.maxResizeHeight
         } else {
-            currentHeight.value.roundToInt()
+            currentHeight
         }
 
     val resizingGridItem = when (dragHandle) {


### PR DESCRIPTION
This commit refactors the animation logic for folder grid items to use a more appropriate animation specification.

Previously, the animation was always applied regardless of the `animate` flag. This change introduces conditional animation using `spring` when `animate` is true and `snap` when it's false, ensuring animations only occur when intended.

Additionally, the `animate` flag in `FolderScreen.kt` was modified to prevent animations when an operation is in progress, improving user experience during folder operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved folder and home-screen grid animations for smoother, more consistent movement and transitions.
  - Improved grid-item and widget resizing with more precise positioning and sizing during drag operations.
  - Updated resize behavior to maintain consistent alignment when dimensions or positions change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->